### PR TITLE
feat: [codex] add rename and move support for files and folders

### DIFF
--- a/apps/nova/src/features/files/api.ts
+++ b/apps/nova/src/features/files/api.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
+import { createCsrfHeaders } from "@/lib/csrf";
 import { stripFileRouteExtension } from "@/lib/file-id";
-import { buildApiUrl, getJson } from "@/lib/http";
+import { buildApiUrl, getJson, patchJson } from "@/lib/http";
 
 const fileDetailsSchema = z.object({
     id: z.string(),
@@ -14,6 +15,23 @@ const fileDetailsSchema = z.object({
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
     storageState: z.enum(["PENDING", "READY", "FAILED"]),
+});
+
+const mutateFileResponseSchema = z.object({
+    status: z.string(),
+    message: z.string(),
+    id: z.string(),
+    folderId: z.string(),
+});
+
+const moveFileInputSchema = z.object({
+    fileId: z.string().min(1),
+    destinationFolderId: z.string().min(1),
+});
+
+const renameFileInputSchema = z.object({
+    fileId: z.string().min(1),
+    name: z.string().trim().min(1),
 });
 
 export type FileDetails = z.infer<typeof fileDetailsSchema>;
@@ -39,4 +57,26 @@ export const buildFileContentUrl = (fileRouteId: string, readToken?: string) => 
 
 export const buildFileThumbnailUrl = (fileRouteId: string, readToken?: string) => {
     return buildApiUrl(`/v1/files/${encodeURIComponent(fileRouteId)}/thumbnail`, { readToken }).toString();
+};
+
+export const moveFile = async (input: z.infer<typeof moveFileInputSchema>) => {
+    const body = moveFileInputSchema.parse(input);
+
+    return patchJson(`/v1/files/${encodeURIComponent(body.fileId)}`, mutateFileResponseSchema, {
+        body: {
+            folderId: body.destinationFolderId,
+        },
+        headers: await createCsrfHeaders(),
+    });
+};
+
+export const renameFile = async (input: z.infer<typeof renameFileInputSchema>) => {
+    const body = renameFileInputSchema.parse(input);
+
+    return patchJson(`/v1/files/${encodeURIComponent(body.fileId)}`, mutateFileResponseSchema, {
+        body: {
+            name: body.name,
+        },
+        headers: await createCsrfHeaders(),
+    });
 };

--- a/apps/nova/src/features/folder/components/file-card.tsx
+++ b/apps/nova/src/features/folder/components/file-card.tsx
@@ -20,6 +20,7 @@ type FileCardProps = {
     folderId: string;
     selected?: boolean;
     onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    onContextMenu?: (event: React.MouseEvent) => void;
 };
 
 const getFileExtension = (name: string) => {
@@ -52,7 +53,7 @@ function isImageFile(fileName: string): boolean {
     return imageExtensions.has(getFileExtensionLower(fileName));
 }
 
-export function FileCard({ id, fileName, folderId, selected, onClick }: FileCardProps) {
+export function FileCard({ id, fileName, folderId, selected, onClick, onContextMenu }: FileCardProps) {
     const router = useRouter();
     const fileRouteId = toFileRouteId(id, fileName);
     const ext = getFileExtension(fileName);
@@ -87,6 +88,7 @@ export function FileCard({ id, fileName, folderId, selected, onClick }: FileCard
     return (
         <div
             onClick={onClick}
+            onContextMenu={onContextMenu}
             onDoubleClick={openPreview}
             onKeyDown={handleKeyDown}
             role="button"

--- a/apps/nova/src/features/folder/components/file-row.tsx
+++ b/apps/nova/src/features/folder/components/file-row.tsx
@@ -19,6 +19,7 @@ type FileRowProps = {
     folderId: string;
     selected?: boolean;
     onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    onContextMenu?: (event: React.MouseEvent) => void;
 };
 
 const getFileExtension = (name: string) => {
@@ -47,7 +48,7 @@ function getFileIcon(fileName: string): ReactNode {
     return <DocumentIcon className="h-5 w-5" />;
 }
 
-export function FileRow({ id, fileName, folderId, selected, onClick }: FileRowProps) {
+export function FileRow({ id, fileName, folderId, selected, onClick, onContextMenu }: FileRowProps) {
     const router = useRouter();
     const fileRouteId = toFileRouteId(id, fileName);
     const ext = getFileExtension(fileName);
@@ -80,6 +81,7 @@ export function FileRow({ id, fileName, folderId, selected, onClick }: FileRowPr
     return (
         <div
             onClick={onClick}
+            onContextMenu={onContextMenu}
             onDoubleClick={openPreview}
             onKeyDown={handleKeyDown}
             role="button"

--- a/apps/nova/src/features/folder/components/folder-card.tsx
+++ b/apps/nova/src/features/folder/components/folder-card.tsx
@@ -6,9 +6,10 @@ type FolderCardProps = {
     name: string;
     selected?: boolean;
     onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    onContextMenu?: (event: React.MouseEvent) => void;
 };
 
-export function FolderCard({ id, name, selected, onClick }: FolderCardProps) {
+export function FolderCard({ id, name, selected, onClick, onContextMenu }: FolderCardProps) {
     const router = useRouter();
 
     const openFolder = () => {
@@ -31,6 +32,7 @@ export function FolderCard({ id, name, selected, onClick }: FolderCardProps) {
     return (
         <div
             onClick={onClick}
+            onContextMenu={onContextMenu}
             onDoubleClick={openFolder}
             onKeyDown={handleKeyDown}
             role="button"

--- a/apps/nova/src/features/folder/components/folder-context-menu.tsx
+++ b/apps/nova/src/features/folder/components/folder-context-menu.tsx
@@ -8,25 +8,36 @@ import {
     TrashIcon,
 } from "@heroicons/react/24/outline";
 import { useRouter } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { ContextMenu, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu";
 import { useToast } from "@/components/ui/toast";
-import { Tooltip } from "@/components/ui/tooltip";
 import { env } from "@/env";
+import { useSelection, type SelectionItem } from "@/features/folder/hooks/use-selection";
 
 type FolderContextMenuProps = {
     folderId: string;
     folderName: string;
     onDelete: (folderId: string) => Promise<void>;
+    onRename: (items: SelectionItem[]) => void;
+    onMove: (items: SelectionItem[]) => void;
     onRefresh: () => void;
     children: React.ReactNode;
 };
 
-export function FolderContextMenu({ folderId, folderName, onDelete, onRefresh, children }: FolderContextMenuProps) {
+export function FolderContextMenu({
+    folderId,
+    folderName,
+    onDelete,
+    onRename,
+    onMove,
+    onRefresh,
+    children,
+}: FolderContextMenuProps) {
     const router = useRouter();
     const { addToast } = useToast();
+    const { selected, selectionCount, isSelected } = useSelection();
     const [deleteOpen, setDeleteOpen] = useState(false);
 
     const handleOpen = () => {
@@ -41,6 +52,17 @@ export function FolderContextMenu({ folderId, folderName, onDelete, onRefresh, c
         await navigator.clipboard.writeText(folderId);
         addToast("Folder ID copied to clipboard", "success");
     };
+
+    const actionTargets = useMemo<SelectionItem[]>(() => {
+        if (selectionCount > 1 && isSelected(folderId)) {
+            return [...selected.values()];
+        }
+
+        return [{ id: folderId, kind: "folder", name: folderName }];
+    }, [selectionCount, isSelected, folderId, selected, folderName]);
+
+    const showRename = actionTargets.length === 1;
+    const showMove = actionTargets.length >= 1;
 
     return (
         <>
@@ -62,17 +84,20 @@ export function FolderContextMenu({ folderId, folderName, onDelete, onRefresh, c
                 <ContextMenuItem icon={<ArrowPathIcon />} onClick={onRefresh}>
                     Refresh
                 </ContextMenuItem>
-                <ContextMenuSeparator />
-                <Tooltip content="Not yet available">
-                    <ContextMenuItem icon={<PencilIcon />} disabled>
+
+                {showRename || showMove ? <ContextMenuSeparator /> : null}
+
+                {showRename ? (
+                    <ContextMenuItem icon={<PencilIcon />} onClick={() => onRename(actionTargets)}>
                         Rename
                     </ContextMenuItem>
-                </Tooltip>
-                <Tooltip content="Not yet available">
-                    <ContextMenuItem icon={<ArrowsRightLeftIcon />} disabled>
+                ) : null}
+
+                {showMove ? (
+                    <ContextMenuItem icon={<ArrowsRightLeftIcon />} onClick={() => onMove(actionTargets)}>
                         Move
                     </ContextMenuItem>
-                </Tooltip>
+                ) : null}
             </ContextMenu>
 
             <ConfirmDialog

--- a/apps/nova/src/features/folder/components/folder-row.tsx
+++ b/apps/nova/src/features/folder/components/folder-row.tsx
@@ -6,9 +6,10 @@ type FolderRowProps = {
     name: string;
     selected?: boolean;
     onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    onContextMenu?: (event: React.MouseEvent) => void;
 };
 
-export function FolderRow({ id, name, selected, onClick }: FolderRowProps) {
+export function FolderRow({ id, name, selected, onClick, onContextMenu }: FolderRowProps) {
     const router = useRouter();
 
     const openFolder = () => {
@@ -31,6 +32,7 @@ export function FolderRow({ id, name, selected, onClick }: FolderRowProps) {
     return (
         <div
             onClick={onClick}
+            onContextMenu={onContextMenu}
             onDoubleClick={openFolder}
             onKeyDown={handleKeyDown}
             role="button"

--- a/apps/nova/src/features/folder/components/move-items-dialog.tsx
+++ b/apps/nova/src/features/folder/components/move-items-dialog.tsx
@@ -68,6 +68,7 @@ export function MoveItemsDialog({
 
     useEffect(() => {
         if (!open) {
+            setFocusedFolderPath([{ id: rootFolderId, name: "/" }]);
             setPending(false);
             setError(null);
             return;

--- a/apps/nova/src/features/folder/components/move-items-dialog.tsx
+++ b/apps/nova/src/features/folder/components/move-items-dialog.tsx
@@ -1,0 +1,218 @@
+import { FolderIcon } from "@heroicons/react/24/outline";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent } from "@/components/ui/dialog";
+import { getFolderDestinationChildren } from "@/features/folder/api";
+import type { SelectionItem } from "@/features/folder/hooks/use-selection";
+import { queryKeys } from "@/lib/query-keys";
+
+type MoveItemsDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    items: SelectionItem[];
+    rootFolderId: string;
+    sourceFolderId: string;
+    onSubmit: (destinationFolderId: string) => Promise<void>;
+};
+
+type FocusedFolderPathItem = {
+    id: string;
+    name: string;
+};
+
+export function MoveItemsDialog({
+    open,
+    onOpenChange,
+    items,
+    rootFolderId,
+    sourceFolderId,
+    onSubmit,
+}: MoveItemsDialogProps) {
+    const [focusedFolderPath, setFocusedFolderPath] = useState<FocusedFolderPathItem[]>(() => [
+        { id: rootFolderId, name: "/" },
+    ]);
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const focusedFolder = focusedFolderPath[focusedFolderPath.length - 1];
+    const focusedFolderId = focusedFolder?.id ?? rootFolderId;
+
+    const destinationChildrenQuery = useQuery({
+        queryKey: queryKeys.folderDestinationChildren(focusedFolderId),
+        queryFn: () => getFolderDestinationChildren(focusedFolderId),
+        enabled: open,
+        staleTime: 60_000,
+    });
+
+    const blockedDestinationIds = useMemo(() => {
+        const blocked = new Set<string>();
+        for (const item of items) {
+            if (item.kind === "folder") {
+                blocked.add(item.id);
+            }
+        }
+        return blocked;
+    }, [items]);
+
+    const childFolders = destinationChildrenQuery.data?.folders ?? [];
+    const isFocusedDestinationBlocked = blockedDestinationIds.has(focusedFolderId);
+    const isNoOpDestination = focusedFolderId === sourceFolderId;
+    const moveDisabled = pending || isFocusedDestinationBlocked || isNoOpDestination;
+    const helperMessage = isFocusedDestinationBlocked
+        ? "Cannot move a folder into itself."
+        : isNoOpDestination
+          ? "Items are already in this folder."
+          : null;
+
+    useEffect(() => {
+        if (!open) {
+            setPending(false);
+            setError(null);
+            return;
+        }
+
+        setFocusedFolderPath([{ id: rootFolderId, name: "/" }]);
+        setPending(false);
+        setError(null);
+    }, [open, rootFolderId]);
+
+    const handleNavigateInto = (folder: { id: string; name: string }) => {
+        if (blockedDestinationIds.has(folder.id)) {
+            return;
+        }
+
+        setFocusedFolderPath((previous) => [...previous, { id: folder.id, name: folder.name }]);
+        setError(null);
+    };
+
+    const handleJumpToPathIndex = (index: number) => {
+        setFocusedFolderPath((previous) => previous.slice(0, index + 1));
+        setError(null);
+    };
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (moveDisabled) {
+            setError(helperMessage ?? "Please choose a valid destination folder");
+            return;
+        }
+
+        setPending(true);
+        setError(null);
+
+        try {
+            await onSubmit(focusedFolderId);
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to move items");
+        } finally {
+            setPending(false);
+        }
+    };
+
+    const itemDescription =
+        items.length === 1 && items[0]
+            ? `${items[0].kind === "file" ? "file" : "folder"} "${items[0].name}"`
+            : `${items.length} items`;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent title="Move Items" description={`Choose a destination folder for ${itemDescription}.`}>
+                <form onSubmit={(event) => void handleSubmit(event)} className="space-y-4">
+                    <div className="border-border bg-surface rounded-lg border p-3">
+                        <p className="text-text-muted mb-1 text-xs font-medium">Current destination</p>
+                        <div className="flex flex-wrap items-center gap-1.5 text-sm">
+                            {focusedFolderPath.map((node, index) => {
+                                const isLast = index === focusedFolderPath.length - 1;
+                                return (
+                                    <div key={node.id} className="flex items-center gap-1.5">
+                                        <button
+                                            type="button"
+                                            onClick={() => handleJumpToPathIndex(index)}
+                                            disabled={isLast}
+                                            className={`rounded px-1.5 py-0.5 ${
+                                                isLast
+                                                    ? "text-text font-medium"
+                                                    : "text-text-muted hover:bg-surface-raised hover:text-text"
+                                            }`}
+                                        >
+                                            {index === 0 ? "/" : node.name}
+                                        </button>
+                                        {!isLast ? <span className="text-text-dim">/</span> : null}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+
+                    {destinationChildrenQuery.isPending ? (
+                        <p className="text-text-muted text-sm">Loading subfolders...</p>
+                    ) : null}
+
+                    {destinationChildrenQuery.error ? (
+                        <div className="space-y-2">
+                            <p className="text-danger text-sm">Failed to load subfolders.</p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => void destinationChildrenQuery.refetch()}
+                            >
+                                Retry
+                            </Button>
+                        </div>
+                    ) : null}
+
+                    {destinationChildrenQuery.data ? (
+                        <div className="border-border bg-surface rounded-lg border">
+                            {childFolders.length === 0 ? (
+                                <p className="text-text-muted px-3 py-3 text-sm">No subfolders in this location.</p>
+                            ) : (
+                                <ul className="divide-border divide-y">
+                                    {childFolders.map((folder) => {
+                                        const blocked = blockedDestinationIds.has(folder.id);
+
+                                        return (
+                                            <li key={folder.id}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleNavigateInto(folder)}
+                                                    disabled={blocked}
+                                                    className="hover:bg-surface-raised disabled:text-text-dim disabled:hover:bg-surface flex w-full items-center justify-between gap-2.5 px-3 py-2 text-left disabled:cursor-not-allowed"
+                                                >
+                                                    <span className="flex items-center gap-2">
+                                                        <FolderIcon className="h-4.5 w-4.5" />
+                                                        <span className="text-sm">{folder.name}</span>
+                                                    </span>
+                                                    <span className="text-text-dim text-xs">
+                                                        {blocked ? "Selected item" : "Open"}
+                                                    </span>
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {helperMessage ? <p className="text-warning text-sm">{helperMessage}</p> : null}
+                    {error ? <p className="text-danger text-sm">{error}</p> : null}
+
+                    <div className="flex items-center justify-end gap-2.5">
+                        <DialogClose>
+                            <Button type="button" variant="ghost" disabled={pending}>
+                                Cancel
+                            </Button>
+                        </DialogClose>
+                        <Button type="submit" loading={pending} disabled={moveDisabled}>
+                            Move Here
+                        </Button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/nova/src/features/folder/components/rename-item-dialog.tsx
+++ b/apps/nova/src/features/folder/components/rename-item-dialog.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import type { SelectionItem } from "@/features/folder/hooks/use-selection";
+
+type RenameItemDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    item: SelectionItem | null;
+    onSubmit: (nextName: string) => Promise<void>;
+};
+
+export function RenameItemDialog({ open, onOpenChange, item, onSubmit }: RenameItemDialogProps) {
+    const [name, setName] = useState("");
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [stableItem, setStableItem] = useState<SelectionItem | null>(item);
+
+    useEffect(() => {
+        if (item) {
+            setStableItem(item);
+        }
+    }, [item]);
+
+    useEffect(() => {
+        if (!open) {
+            setPending(false);
+            setError(null);
+            setName("");
+            return;
+        }
+
+        setPending(false);
+        setError(null);
+        setName(item?.name ?? "");
+    }, [open, item]);
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (!item) {
+            return;
+        }
+
+        const nextName = name.trim();
+        if (!nextName) {
+            setError("Name cannot be empty");
+            return;
+        }
+
+        if (nextName === item.name) {
+            onOpenChange(false);
+            return;
+        }
+
+        setPending(true);
+        setError(null);
+
+        try {
+            await onSubmit(nextName);
+            onOpenChange(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to rename item");
+        } finally {
+            setPending(false);
+        }
+    };
+
+    const title = stableItem ? `Rename ${stableItem.kind === "file" ? "File" : "Folder"}` : "Rename Item";
+    const description = stableItem ? `Enter a new name for "${stableItem.name}".` : "Enter a new name.";
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent title={title} description={description}>
+                <form onSubmit={(event) => void handleSubmit(event)} className="space-y-5">
+                    <Input
+                        label="Name"
+                        placeholder="Enter a new name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        required
+                        autoFocus
+                        error={error ?? undefined}
+                    />
+
+                    <div className="flex items-center justify-end gap-2.5">
+                        <DialogClose>
+                            <Button type="button" variant="ghost" disabled={pending}>
+                                Cancel
+                            </Button>
+                        </DialogClose>
+                        <Button type="submit" loading={pending}>
+                            Rename
+                        </Button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/nova/src/features/folder/components/selection-toolbar.tsx
+++ b/apps/nova/src/features/folder/components/selection-toolbar.tsx
@@ -1,4 +1,12 @@
-import { ArrowDownTrayIcon, InformationCircleIcon, LinkIcon, TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+    ArrowDownTrayIcon,
+    ArrowsRightLeftIcon,
+    InformationCircleIcon,
+    LinkIcon,
+    PencilIcon,
+    TrashIcon,
+    XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -13,9 +21,17 @@ type SelectionToolbarProps = {
     onDeleteFiles: (fileIds: string[]) => Promise<void>;
     onDeleteFolders: (folderIds: string[]) => Promise<void>;
     onShowInfo: (item: SelectionItem) => void;
+    onRename: (item: SelectionItem) => void;
+    onMove: (items: SelectionItem[]) => void;
 };
 
-export function SelectionToolbar({ onDeleteFiles, onDeleteFolders, onShowInfo }: SelectionToolbarProps) {
+export function SelectionToolbar({
+    onDeleteFiles,
+    onDeleteFolders,
+    onShowInfo,
+    onRename,
+    onMove,
+}: SelectionToolbarProps) {
     const { selectionCount, selectedFiles, selectedFolders, clearSelection, selected } = useSelection();
     const { addToast } = useToast();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -51,6 +67,15 @@ export function SelectionToolbar({ onDeleteFiles, onDeleteFolders, onShowInfo }:
     const handleInfo = () => {
         if (!singleItem) return;
         onShowInfo(singleItem);
+    };
+
+    const handleRename = () => {
+        if (!singleItem) return;
+        onRename(singleItem);
+    };
+
+    const handleMove = () => {
+        onMove([...selected.values()]);
     };
 
     const handleDelete = async () => {
@@ -99,6 +124,18 @@ export function SelectionToolbar({ onDeleteFiles, onDeleteFolders, onShowInfo }:
             <Button variant="ghost" size="sm" onClick={handleInfo} disabled={!isSingleItem} aria-label="Info">
                 <InformationCircleIcon className="h-4.5 w-4.5" />
                 Info
+            </Button>
+
+            {isSingleItem ? (
+                <Button variant="ghost" size="sm" onClick={handleRename} aria-label="Rename">
+                    <PencilIcon className="h-4.5 w-4.5" />
+                    Rename
+                </Button>
+            ) : null}
+
+            <Button variant="ghost" size="sm" onClick={handleMove} aria-label="Move selected">
+                <ArrowsRightLeftIcon className="h-4.5 w-4.5" />
+                Move
             </Button>
 
             <div className="bg-border mx-0.5 h-7 w-px" />

--- a/apps/nova/src/lib/query-keys.ts
+++ b/apps/nova/src/lib/query-keys.ts
@@ -7,6 +7,7 @@ export const queryKeys = {
     folderContents: (folderId: string) => ["folder", "contents", folderId] as const,
     fileDetails: (fileId: string, readToken?: string) => ["file", "details", fileId, readToken] as const,
     folderDisplayOrder: (folderId: string) => ["folder", "display-order", folderId] as const,
+    folderDestinationChildren: (folderId: string) => ["folder", "destination-children", folderId] as const,
     recycleBinList: (itemType?: "FILE" | "FOLDER", limit?: number, offset?: number) =>
         ["recycle-bin", "list", itemType ?? "ALL", limit ?? null, offset ?? 0] as const,
     recycleBinDestinationFolders: (search?: string, limit?: number) =>

--- a/apps/nova/src/routes/_authed.folder.$folderId.tsx
+++ b/apps/nova/src/routes/_authed.folder.$folderId.tsx
@@ -389,7 +389,10 @@ function FolderPageContent({
                     await onRenameFolder(renameTarget.id, nextName);
                 }
 
-                await queryClient.invalidateQueries({ queryKey: queryKeys.folderContents(folderId) });
+                await Promise.all([
+                    queryClient.invalidateQueries({ queryKey: queryKeys.folderContents(folderId) }),
+                    queryClient.invalidateQueries({ queryKey: ["folder", "destination-children"] }),
+                ]);
 
                 addToast(`${renameTarget.kind === "file" ? "File" : "Folder"} renamed`, "success");
             } catch (error) {

--- a/apps/nova/src/routes/_authed.folder.$folderId.tsx
+++ b/apps/nova/src/routes/_authed.folder.$folderId.tsx
@@ -431,6 +431,7 @@ function FolderPageContent({
                 await Promise.all([
                     queryClient.invalidateQueries({ queryKey: queryKeys.folderContents(folderId) }),
                     queryClient.invalidateQueries({ queryKey: queryKeys.folderContents(destinationFolderId) }),
+                    queryClient.invalidateQueries({ queryKey: ["folder", "destination-children"] }),
                 ]);
                 clearSelection();
             }

--- a/apps/server/src/systems/folder/folder.routes.ts
+++ b/apps/server/src/systems/folder/folder.routes.ts
@@ -7,6 +7,7 @@ import {
     getDetailsHandler,
     getDisplayPreferencesHandler,
     listChildrenHandler,
+    listDestinationChildrenHandler,
     patchFolderHandler,
     putDisplayPreferencesHandler,
 } from "./folder.handlers";
@@ -36,6 +37,18 @@ async function folderRouter(server: FastifyInstance) {
             response: { 200: $ref("getFolderChildrenResponseSchema") },
         },
         handler: listChildrenHandler,
+    });
+
+    server.route({
+        method: "GET",
+        url: "/folders/:folderId/destination-children",
+        onRequest: [server.optionalAuthenticate],
+        preValidation: [server.authenticate],
+        schema: {
+            params: $ref("folderParamsSchema"),
+            response: { 200: $ref("getFolderDestinationChildrenResponseSchema") },
+        },
+        handler: listDestinationChildrenHandler,
     });
 
     server.route({

--- a/apps/server/src/systems/folder/folder.schemas.ts
+++ b/apps/server/src/systems/folder/folder.schemas.ts
@@ -59,6 +59,18 @@ const getFolderChildrenResponseSchema = z.object({
     offset: z.number().int().optional(),
 });
 
+const getFolderDestinationChildrenResponseSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    parentFolderId: z.string().nullable(),
+    folders: z.array(
+        z.object({
+            id: z.string(),
+            name: z.string(),
+        }),
+    ),
+});
+
 const createFolderSchema = z.object({
     name: z.string({
         required_error: "Folder name is required",
@@ -74,12 +86,28 @@ const createFolderResponseSchema = z.object({
     id: z.string(),
 });
 
-const patchFolderBodySchema = z.object({
-    destinationFolderId: z.string({
-        required_error: "Destination folder ID is required",
-        invalid_type_error: "Destination folder ID must be a string",
-    }),
-});
+const patchFolderMoveBodySchema = z
+    .object({
+        destinationFolderId: z.string({
+            required_error: "Destination folder ID is required",
+            invalid_type_error: "Destination folder ID must be a string",
+        }),
+    })
+    .strict();
+
+const patchFolderRenameBodySchema = z
+    .object({
+        name: z
+            .string({
+                required_error: "Folder name is required",
+                invalid_type_error: "Folder name must be a string",
+            })
+            .trim()
+            .min(1, { message: "Folder name cannot be empty" }),
+    })
+    .strict();
+
+const patchFolderBodySchema = z.union([patchFolderMoveBodySchema, patchFolderRenameBodySchema]);
 
 const mutateFolderResponseSchema = z.object({
     status: z.string(),
@@ -113,6 +141,7 @@ export const { schemas: folderSchemas, $ref } = buildJsonSchemas(
         getFolderDetailsResponseSchema,
         getFolderChildrenQuerySchema,
         getFolderChildrenResponseSchema,
+        getFolderDestinationChildrenResponseSchema,
         createFolderSchema,
         createFolderResponseSchema,
         patchFolderBodySchema,

--- a/apps/server/src/systems/fs/fs.schemas.ts
+++ b/apps/server/src/systems/fs/fs.schemas.ts
@@ -26,12 +26,28 @@ const fileDetailsResponseSchema = z.object({
     storageState: z.enum(["PENDING", "READY", "FAILED"]),
 });
 
-const patchFileBodySchema = z.object({
-    folderId: z.string({
-        required_error: "Destination folder ID is required",
-        invalid_type_error: "Destination folder ID must be a string",
-    }),
-});
+const patchFileMoveBodySchema = z
+    .object({
+        folderId: z.string({
+            required_error: "Destination folder ID is required",
+            invalid_type_error: "Destination folder ID must be a string",
+        }),
+    })
+    .strict();
+
+const patchFileRenameBodySchema = z
+    .object({
+        name: z
+            .string({
+                required_error: "File name is required",
+                invalid_type_error: "File name must be a string",
+            })
+            .trim()
+            .min(1, { message: "File name cannot be empty" }),
+    })
+    .strict();
+
+const patchFileBodySchema = z.union([patchFileMoveBodySchema, patchFileRenameBodySchema]);
 
 const mutateFileResponseSchema = z.object({
     status: z.string(),


### PR DESCRIPTION
## Summary
This change adds end-to-end rename and move support for files and folders across the server and Nova app, including single-item actions and multi-select flows.

## User Impact
Before this change, users could not reliably rename or move items from the folder view without workarounds. This limited file organization and could leave the UI showing stale data after certain operations.

## Root Cause
The rename/move capability was incomplete across layers:
- Server systems were missing the full set of route/schema/handler coverage for rename and move operations.
- Nova UI did not expose dedicated rename/move workflows for all list/card/context menu entry points.
- Client cache invalidation did not consistently refresh affected folder/file queries after move operations.

## What Changed
- Added/updated server-side folder and filesystem route handlers/schemas to support rename and move operations.
- Extended Nova API clients for folder/file mutations.
- Added new Nova dialogs for rename and move flows:
  - `rename-item-dialog.tsx`
  - `move-items-dialog.tsx`
- Wired rename/move entry points into file/folder row + card context menus and the selection toolbar.
- Updated route-level folder page behavior to handle the new workflows.
- Added missing query key usage and invalidation updates so UI state refreshes after move/rename.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
