### PR TITLE
[codex] perf(nova): improve item select performance

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-apps/nova/src/routeTree.gen.ts
+**/routeTree.gen.ts

--- a/apps/nova/eslint.config.js
+++ b/apps/nova/eslint.config.js
@@ -5,7 +5,7 @@ export default tseslint.config(
     js.configs.recommended,
     ...tseslint.configs.recommended,
     {
-        ignores: ["dist/**", ".output/**", ".vinxi/**", ".tanstack/**", "node_modules/**", "src/routeTree.gen.ts"],
+        ignores: ["dist/**", ".output/**", ".vinxi/**", ".tanstack/**", "node_modules/**", "**/routeTree.gen.ts"],
     },
     {
         files: ["**/*.{ts,tsx}"],

--- a/apps/nova/package.json
+++ b/apps/nova/package.json
@@ -24,6 +24,7 @@
         "@tanstack/react-query": "^5.84.2",
         "@tanstack/react-router": "^1.132.0",
         "@tanstack/react-start": "^1.132.0",
+        "@tanstack/react-virtual": "^3.13.12",
         "@tanstack/router-plugin": "^1.132.0",
         "better-auth": "^1.4.18",
         "react": "19.2.3",

--- a/apps/nova/src/features/folder/components/selection-provider.tsx
+++ b/apps/nova/src/features/folder/components/selection-provider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
 
 import { SelectionContext, SelectionStore, type SelectionItem } from "@/features/folder/hooks/use-selection";
 
@@ -7,6 +7,8 @@ type SelectionProviderProps = {
     itemsById: Map<string, SelectionItem>;
     children: ReactNode;
 };
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 export function SelectionProvider({ orderedIds, itemsById, children }: SelectionProviderProps) {
     const storeRef = useRef<SelectionStore | null>(null);
@@ -17,7 +19,7 @@ export function SelectionProvider({ orderedIds, itemsById, children }: Selection
 
     const store = storeRef.current;
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         store.updateSourceData(orderedIds, itemsById);
     }, [store, orderedIds, itemsById]);
 

--- a/apps/nova/src/features/folder/components/selection-provider.tsx
+++ b/apps/nova/src/features/folder/components/selection-provider.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
-import { SelectionContext, useSelectionState, type SelectionItem } from "@/features/folder/hooks/use-selection";
+import { SelectionContext, SelectionStore, type SelectionItem } from "@/features/folder/hooks/use-selection";
 
 type SelectionProviderProps = {
     orderedIds: string[];
@@ -9,7 +9,17 @@ type SelectionProviderProps = {
 };
 
 export function SelectionProvider({ orderedIds, itemsById, children }: SelectionProviderProps) {
-    const selection = useSelectionState(orderedIds, itemsById);
+    const storeRef = useRef<SelectionStore | null>(null);
 
-    return <SelectionContext.Provider value={selection}>{children}</SelectionContext.Provider>;
+    if (!storeRef.current) {
+        storeRef.current = new SelectionStore(orderedIds, itemsById);
+    }
+
+    const store = storeRef.current;
+
+    useEffect(() => {
+        store.updateSourceData(orderedIds, itemsById);
+    }, [store, orderedIds, itemsById]);
+
+    return <SelectionContext.Provider value={store}>{children}</SelectionContext.Provider>;
 }

--- a/apps/nova/src/features/folder/components/selection-toolbar.tsx
+++ b/apps/nova/src/features/folder/components/selection-toolbar.tsx
@@ -14,7 +14,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useToast } from "@/components/ui/toast";
 import { env } from "@/env";
 import { buildFileContentUrl } from "@/features/files/api";
-import { useSelection, type SelectionItem } from "@/features/folder/hooks/use-selection";
+import { useSelectedItems, useSelectionActions, type SelectionItem } from "@/features/folder/hooks/use-selection";
 import { toFileRouteId } from "@/lib/file-id";
 
 type SelectionToolbarProps = {
@@ -32,7 +32,8 @@ export function SelectionToolbar({
     onRename,
     onMove,
 }: SelectionToolbarProps) {
-    const { selectionCount, selectedFiles, selectedFolders, clearSelection, selected } = useSelection();
+    const { selected, selectedFiles, selectedFolders, selectionCount } = useSelectedItems();
+    const { clearSelection } = useSelectionActions();
     const { addToast } = useToast();
     const [deleteOpen, setDeleteOpen] = useState(false);
 

--- a/apps/nova/src/features/folder/components/virtualized-item-section.tsx
+++ b/apps/nova/src/features/folder/components/virtualized-item-section.tsx
@@ -114,11 +114,27 @@ export function VirtualizedItemSection<TItem>({
         return listEstimateHeight + listGapPx;
     }, [displayType, gridEstimateHeight, gridGapPx, listEstimateHeight, listGapPx]);
 
+    const getVirtualRowKey = useCallback(
+        (rowIndex: number) => {
+            if (displayType === "GRID") {
+                const start = rowIndex * columnCount;
+                const firstItem = items[start];
+
+                return firstItem ? `grid:${getItemId(firstItem)}` : `grid-row:${rowIndex}`;
+            }
+
+            const item = items[rowIndex];
+            return item ? getItemId(item) : `list-row:${rowIndex}`;
+        },
+        [displayType, columnCount, items, getItemId],
+    );
+
     const virtualizer = useWindowVirtualizer({
         count: rowCount,
         estimateSize,
         overscan,
         scrollMargin,
+        getItemKey: getVirtualRowKey,
     });
 
     const virtualRows = virtualizer.getVirtualItems();

--- a/apps/nova/src/features/folder/components/virtualized-item-section.tsx
+++ b/apps/nova/src/features/folder/components/virtualized-item-section.tsx
@@ -1,0 +1,154 @@
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
+
+import type { DisplayType } from "@/features/folder/api";
+
+type VirtualizedItemSectionProps<TItem> = {
+    items: TItem[];
+    getItemId: (item: TItem) => string;
+    renderItem: (item: TItem) => ReactNode;
+    displayType: DisplayType;
+    gridMinColumnWidth: number;
+    gridGapPx: number;
+    gridEstimateHeight: number;
+    listEstimateHeight: number;
+    listGapPx?: number;
+    overscan?: number;
+    layoutKey?: string | number | boolean;
+};
+
+export function VirtualizedItemSection<TItem>({
+    items,
+    getItemId,
+    renderItem,
+    displayType,
+    gridMinColumnWidth,
+    gridGapPx,
+    gridEstimateHeight,
+    listEstimateHeight,
+    listGapPx = 2,
+    overscan = 8,
+    layoutKey,
+}: VirtualizedItemSectionProps<TItem>) {
+    const sectionRef = useRef<HTMLDivElement | null>(null);
+    const [columnCount, setColumnCount] = useState(1);
+    const [scrollMargin, setScrollMargin] = useState(0);
+
+    const measureLayout = useCallback(() => {
+        const section = sectionRef.current;
+        if (!section || typeof window === "undefined") {
+            return;
+        }
+
+        const nextScrollMargin = section.getBoundingClientRect().top + window.scrollY;
+        setScrollMargin((previous) => (Math.abs(previous - nextScrollMargin) < 1 ? previous : nextScrollMargin));
+
+        const width = section.clientWidth;
+        const nextColumnCount = Math.max(1, Math.floor((width + gridGapPx) / (gridMinColumnWidth + gridGapPx)));
+        setColumnCount((previous) => (previous === nextColumnCount ? previous : nextColumnCount));
+    }, [gridGapPx, gridMinColumnWidth]);
+
+    useEffect(() => {
+        measureLayout();
+    }, [measureLayout, items.length, displayType, layoutKey]);
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const onWindowResize = () => {
+            measureLayout();
+        };
+
+        window.addEventListener("resize", onWindowResize);
+
+        let resizeObserver: ResizeObserver | null = null;
+        if (typeof ResizeObserver !== "undefined" && sectionRef.current) {
+            resizeObserver = new ResizeObserver(() => {
+                measureLayout();
+            });
+            resizeObserver.observe(sectionRef.current);
+        }
+
+        return () => {
+            window.removeEventListener("resize", onWindowResize);
+            resizeObserver?.disconnect();
+        };
+    }, [measureLayout]);
+
+    const rowCount = useMemo(() => {
+        if (displayType === "GRID") {
+            return Math.ceil(items.length / Math.max(columnCount, 1));
+        }
+
+        return items.length;
+    }, [displayType, items.length, columnCount]);
+
+    const estimateSize = useCallback(() => {
+        if (displayType === "GRID") {
+            return gridEstimateHeight + gridGapPx;
+        }
+
+        return listEstimateHeight + listGapPx;
+    }, [displayType, gridEstimateHeight, gridGapPx, listEstimateHeight, listGapPx]);
+
+    const virtualizer = useWindowVirtualizer({
+        count: rowCount,
+        estimateSize,
+        overscan,
+        scrollMargin,
+    });
+
+    const virtualRows = virtualizer.getVirtualItems();
+    const totalSize = virtualizer.getTotalSize();
+
+    return (
+        <div ref={sectionRef} className="relative w-full">
+            <div className="relative w-full" style={{ height: `${totalSize}px` }}>
+                {virtualRows.map((virtualRow) => {
+                    const baseStyle: CSSProperties = {
+                        transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                    };
+
+                    if (displayType === "GRID") {
+                        const start = virtualRow.index * columnCount;
+                        const end = Math.min(start + columnCount, items.length);
+                        const rowItems = items.slice(start, end);
+                        const isLastRow = virtualRow.index === rowCount - 1;
+
+                        return (
+                            <div key={virtualRow.key} className="absolute top-0 left-0 w-full" style={baseStyle}>
+                                <div
+                                    className="grid"
+                                    style={{
+                                        gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+                                        columnGap: `${gridGapPx}px`,
+                                        paddingBottom: isLastRow ? 0 : `${gridGapPx}px`,
+                                    }}
+                                >
+                                    {rowItems.map((item) => (
+                                        <div key={getItemId(item)}>{renderItem(item)}</div>
+                                    ))}
+                                </div>
+                            </div>
+                        );
+                    }
+
+                    const item = items[virtualRow.index];
+                    if (!item) {
+                        return null;
+                    }
+
+                    const isLastItem = virtualRow.index === items.length - 1;
+
+                    return (
+                        <div key={virtualRow.key} className="absolute top-0 left-0 w-full" style={baseStyle}>
+                            <div style={{ paddingBottom: isLastItem ? 0 : `${listGapPx}px` }}>{renderItem(item)}</div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/apps/nova/src/features/folder/hooks/use-selection.ts
+++ b/apps/nova/src/features/folder/hooks/use-selection.ts
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
 
 export type SelectionItem = {
     id: string;
@@ -12,172 +12,436 @@ export type SelectionInputEvent = {
     shiftKey: boolean;
 };
 
-type SelectionContextValue = {
+export type SelectedItemsSnapshot = {
     selected: Map<string, SelectionItem>;
-    isSelected: (id: string) => boolean;
+    selectedFiles: SelectionItem[];
+    selectedFolders: SelectionItem[];
     selectionCount: number;
+};
+
+export type SelectionActions = {
     handleItemClick: (item: SelectionItem, event: SelectionInputEvent) => void;
     clearSelection: () => void;
     selectAll: (items: SelectionItem[]) => void;
-    selectedFiles: SelectionItem[];
-    selectedFolders: SelectionItem[];
+    resolveActionTargets: (fallbackItem: SelectionItem) => SelectionItem[];
+    getSelectedItemsSnapshot: () => SelectedItemsSnapshot;
 };
 
-const SelectionContext = createContext<SelectionContextValue | null>(null);
+const EMPTY_SELECTED_ITEMS_SNAPSHOT: SelectedItemsSnapshot = {
+    selected: new Map<string, SelectionItem>(),
+    selectedFiles: [],
+    selectedFolders: [],
+    selectionCount: 0,
+};
 
-export function useSelection(): SelectionContextValue {
-    const ctx = useContext(SelectionContext);
-    if (!ctx) {
-        throw new Error("useSelection must be used within a SelectionProvider");
+const EMPTY_COUNT = 0;
+const EMPTY_SELECTED = false;
+const EMPTY_MULTI_SELECTED = false;
+
+const isSelectionPerfDebugEnabled = () => {
+    if (!import.meta.env.DEV || typeof window === "undefined") {
+        return false;
     }
-    return ctx;
-}
 
-export { SelectionContext };
+    return (window as Window & { __OC_SELECTION_PERF__?: boolean }).__OC_SELECTION_PERF__ === true;
+};
 
-/**
- * Core selection state management.
- *
- * @param orderedIds Flat array of all item IDs in render order (folders first, then files).
- * @param itemsById Lookup map so shift-range selection can resolve SelectionItem metadata.
- */
-export function useSelectionState(orderedIds: string[], itemsById: Map<string, SelectionItem>) {
-    const [selected, setSelected] = useState<Map<string, SelectionItem>>(() => new Map());
-    const lastClickedIdRef = useRef<string | null>(null);
+export class SelectionStore {
+    private orderedIds: string[] = [];
+    private orderedIndexById = new Map<string, number>();
+    private itemsById = new Map<string, SelectionItem>();
 
-    // Keep stable refs so the handleItemClick callback doesn't need these as deps
-    const orderedIdsRef = useRef(orderedIds);
-    orderedIdsRef.current = orderedIds;
-    const itemsByIdRef = useRef(itemsById);
-    itemsByIdRef.current = itemsById;
+    private selected = new Map<string, SelectionItem>();
+    private selectedFiles: SelectionItem[] = [];
+    private selectedFolders: SelectionItem[] = [];
+    private selectedSnapshot: SelectedItemsSnapshot = EMPTY_SELECTED_ITEMS_SNAPSHOT;
 
-    useEffect(() => {
-        const availableIds = new Set(orderedIds);
+    private lastClickedId: string | null = null;
 
-        setSelected((previous) => {
-            if (previous.size === 0) {
-                return previous;
-            }
+    private selectionListeners = new Set<() => void>();
+    private selectionCountListeners = new Set<() => void>();
+    private itemListeners = new Map<string, Set<() => void>>();
 
-            let changed = false;
-            const next = new Map<string, SelectionItem>();
+    public readonly actions: SelectionActions = {
+        handleItemClick: (item, event) => {
+            this.runMeasuredAction("handleItemClick", () => {
+                this.handleItemClickInternal(item, event);
+            });
+        },
+        clearSelection: () => {
+            this.runMeasuredAction("clearSelection", () => {
+                this.clearSelectionInternal();
+            });
+        },
+        selectAll: (items) => {
+            this.runMeasuredAction("selectAll", () => {
+                this.selectAllInternal(items);
+            });
+        },
+        resolveActionTargets: (fallbackItem) => this.resolveActionTargets(fallbackItem),
+        getSelectedItemsSnapshot: () => this.getSelectedItemsSnapshot(),
+    };
 
-            for (const [id, item] of previous) {
-                const resolved = availableIds.has(id) ? itemsById.get(id) : undefined;
-                if (!resolved) {
-                    changed = true;
-                    continue;
-                }
+    constructor(orderedIds: string[], itemsById: Map<string, SelectionItem>) {
+        this.updateSourceData(orderedIds, itemsById);
+    }
 
-                next.set(id, resolved);
-                if (resolved.kind !== item.kind || resolved.name !== item.name) {
-                    changed = true;
-                }
-            }
+    public updateSourceData(orderedIds: string[], itemsById: Map<string, SelectionItem>) {
+        this.orderedIds = orderedIds;
+        this.itemsById = itemsById;
+        this.orderedIndexById = new Map(orderedIds.map((id, index) => [id, index]));
 
-            if (!changed && next.size === previous.size) {
-                return previous;
-            }
-
-            return next;
-        });
-
-        if (lastClickedIdRef.current && !availableIds.has(lastClickedIdRef.current)) {
-            lastClickedIdRef.current = null;
+        if (this.lastClickedId && !this.orderedIndexById.has(this.lastClickedId)) {
+            this.lastClickedId = null;
         }
-    }, [orderedIds, itemsById]);
 
-    const isSelected = useCallback((id: string) => selected.has(id), [selected]);
-    const selectionCount = selected.size;
-
-    const clearSelection = useCallback(() => {
-        setSelected(new Map());
-        lastClickedIdRef.current = null;
-    }, []);
-
-    const selectAll = useCallback((items: SelectionItem[]) => {
-        const next = new Map<string, SelectionItem>();
-        for (const item of items) {
-            next.set(item.id, item);
+        if (this.selected.size === 0) {
+            return;
         }
-        setSelected(next);
-        lastClickedIdRef.current = null;
-    }, []);
 
-    const handleItemClick = useCallback((item: SelectionItem, event: SelectionInputEvent) => {
+        let changed = false;
+        const nextSelected = new Map<string, SelectionItem>();
+        const changedIds = new Set<string>();
+
+        for (const [id, item] of this.selected) {
+            const resolved = this.itemsById.get(id);
+            if (!resolved) {
+                changed = true;
+                changedIds.add(id);
+                continue;
+            }
+
+            nextSelected.set(id, resolved);
+            if (resolved.kind !== item.kind || resolved.name !== item.name) {
+                changed = true;
+                changedIds.add(id);
+            }
+        }
+
+        if (!changed && nextSelected.size === this.selected.size) {
+            return;
+        }
+
+        this.commitSelected(nextSelected, changedIds);
+    }
+
+    public getSelectionCount() {
+        return this.selected.size;
+    }
+
+    public getSelectedItemsSnapshot() {
+        return this.selectedSnapshot;
+    }
+
+    public isSelected(id: string) {
+        return this.selected.has(id);
+    }
+
+    public isItemInMultiSelection(id: string) {
+        return this.selected.size > 1 && this.selected.has(id);
+    }
+
+    public subscribeSelection(listener: () => void) {
+        this.selectionListeners.add(listener);
+        return () => {
+            this.selectionListeners.delete(listener);
+        };
+    }
+
+    public subscribeSelectionCount(listener: () => void) {
+        this.selectionCountListeners.add(listener);
+        return () => {
+            this.selectionCountListeners.delete(listener);
+        };
+    }
+
+    public subscribeItem(id: string, listener: () => void) {
+        let listeners = this.itemListeners.get(id);
+        if (!listeners) {
+            listeners = new Set<() => void>();
+            this.itemListeners.set(id, listeners);
+        }
+
+        listeners.add(listener);
+
+        return () => {
+            const current = this.itemListeners.get(id);
+            if (!current) {
+                return;
+            }
+
+            current.delete(listener);
+
+            if (current.size === 0) {
+                this.itemListeners.delete(id);
+            }
+        };
+    }
+
+    private handleItemClickInternal(item: SelectionItem, event: SelectionInputEvent) {
         const isMeta = event.metaKey || event.ctrlKey;
         const isShift = event.shiftKey;
 
-        if (isShift && lastClickedIdRef.current) {
-            const ids = orderedIdsRef.current;
-            const lookup = itemsByIdRef.current;
-            const anchorIndex = ids.indexOf(lastClickedIdRef.current);
-            const targetIndex = ids.indexOf(item.id);
+        if (isShift && this.lastClickedId) {
+            const anchorIndex = this.orderedIndexById.get(this.lastClickedId);
+            const targetIndex = this.orderedIndexById.get(item.id);
 
-            if (anchorIndex >= 0 && targetIndex >= 0) {
+            if (anchorIndex !== undefined && targetIndex !== undefined) {
                 const start = Math.min(anchorIndex, targetIndex);
                 const end = Math.max(anchorIndex, targetIndex);
 
-                setSelected((prev) => {
-                    const next = isMeta ? new Map(prev) : new Map<string, SelectionItem>();
-                    for (let i = start; i <= end; i++) {
-                        const id = ids[i];
-                        if (id !== undefined) {
-                            const resolved = lookup.get(id);
-                            if (resolved) {
-                                next.set(id, resolved);
-                            }
-                        }
+                const next = isMeta ? new Map(this.selected) : new Map<string, SelectionItem>();
+
+                for (let i = start; i <= end; i++) {
+                    const id = this.orderedIds[i];
+                    if (!id) {
+                        continue;
                     }
-                    return next;
-                });
+
+                    const resolved = this.itemsById.get(id);
+                    if (resolved) {
+                        next.set(id, resolved);
+                    }
+                }
+
+                this.commitSelected(next);
             }
-            // Don't update lastClickedId on shift-click — keep the anchor
+
+            // Keep anchor stable for shift-range additions.
             return;
         }
 
         if (isMeta) {
-            setSelected((prev) => {
-                const next = new Map(prev);
-                if (next.has(item.id)) {
-                    next.delete(item.id);
-                } else {
-                    next.set(item.id, item);
-                }
-                return next;
-            });
+            const next = new Map(this.selected);
+            if (next.has(item.id)) {
+                next.delete(item.id);
+            } else {
+                next.set(item.id, item);
+            }
+            this.commitSelected(next);
         } else {
             const next = new Map<string, SelectionItem>();
             next.set(item.id, item);
-            setSelected(next);
+            this.commitSelected(next);
         }
 
-        lastClickedIdRef.current = item.id;
-    }, []);
+        this.lastClickedId = item.id;
+    }
 
-    const selectedFiles = useMemo(() => [...selected.values()].filter((i) => i.kind === "file"), [selected]);
-    const selectedFolders = useMemo(() => [...selected.values()].filter((i) => i.kind === "folder"), [selected]);
+    private clearSelectionInternal() {
+        if (this.selected.size > 0) {
+            this.commitSelected(new Map<string, SelectionItem>());
+        }
 
-    return useMemo(
-        () => ({
-            selected,
-            isSelected,
-            selectionCount,
-            handleItemClick,
-            clearSelection,
-            selectAll,
-            selectedFiles,
-            selectedFolders,
-        }),
-        [
-            selected,
-            isSelected,
-            selectionCount,
-            handleItemClick,
-            clearSelection,
-            selectAll,
-            selectedFiles,
-            selectedFolders,
-        ],
+        this.lastClickedId = null;
+    }
+
+    private selectAllInternal(items: SelectionItem[]) {
+        const next = new Map<string, SelectionItem>();
+        for (const item of items) {
+            next.set(item.id, item);
+        }
+
+        this.commitSelected(next);
+        this.lastClickedId = null;
+    }
+
+    private resolveActionTargets(fallbackItem: SelectionItem) {
+        if (this.selected.size > 1 && this.selected.has(fallbackItem.id)) {
+            return [...this.selected.values()];
+        }
+
+        return [fallbackItem];
+    }
+
+    private commitSelected(nextSelected: Map<string, SelectionItem>, knownChangedIds?: Set<string>) {
+        const previousSelected = this.selected;
+
+        if (this.areSelectionsEquivalent(previousSelected, nextSelected)) {
+            return;
+        }
+
+        this.selected = nextSelected;
+        this.rebuildDerivedSelection();
+        this.notifySelectionListeners(previousSelected, nextSelected, knownChangedIds);
+    }
+
+    private rebuildDerivedSelection() {
+        const nextFiles: SelectionItem[] = [];
+        const nextFolders: SelectionItem[] = [];
+
+        for (const item of this.selected.values()) {
+            if (item.kind === "file") {
+                nextFiles.push(item);
+            } else {
+                nextFolders.push(item);
+            }
+        }
+
+        this.selectedFiles = nextFiles;
+        this.selectedFolders = nextFolders;
+        this.selectedSnapshot = {
+            selected: this.selected,
+            selectedFiles: this.selectedFiles,
+            selectedFolders: this.selectedFolders,
+            selectionCount: this.selected.size,
+        };
+    }
+
+    private notifySelectionListeners(
+        previousSelected: Map<string, SelectionItem>,
+        nextSelected: Map<string, SelectionItem>,
+        knownChangedIds?: Set<string>,
+    ) {
+        for (const listener of this.selectionListeners) {
+            listener();
+        }
+
+        if (previousSelected.size !== nextSelected.size) {
+            for (const listener of this.selectionCountListeners) {
+                listener();
+            }
+        }
+
+        const idsToNotify = knownChangedIds
+            ? new Set(knownChangedIds)
+            : this.computeChangedIds(previousSelected, nextSelected);
+
+        if (previousSelected.size === 1 || nextSelected.size === 1) {
+            for (const id of previousSelected.keys()) {
+                idsToNotify.add(id);
+            }
+            for (const id of nextSelected.keys()) {
+                idsToNotify.add(id);
+            }
+        }
+
+        for (const id of idsToNotify) {
+            const listeners = this.itemListeners.get(id);
+            if (!listeners) {
+                continue;
+            }
+
+            for (const listener of listeners) {
+                listener();
+            }
+        }
+    }
+
+    private computeChangedIds(previous: Map<string, SelectionItem>, next: Map<string, SelectionItem>) {
+        const changedIds = new Set<string>();
+
+        for (const [id, item] of previous) {
+            const nextItem = next.get(id);
+            if (!nextItem) {
+                changedIds.add(id);
+                continue;
+            }
+
+            if (nextItem.kind !== item.kind || nextItem.name !== item.name) {
+                changedIds.add(id);
+            }
+        }
+
+        for (const id of next.keys()) {
+            if (!previous.has(id)) {
+                changedIds.add(id);
+            }
+        }
+
+        return changedIds;
+    }
+
+    private areSelectionsEquivalent(previous: Map<string, SelectionItem>, next: Map<string, SelectionItem>) {
+        if (previous.size !== next.size) {
+            return false;
+        }
+
+        for (const [id, previousItem] of previous) {
+            const nextItem = next.get(id);
+            if (!nextItem) {
+                return false;
+            }
+
+            if (nextItem.kind !== previousItem.kind || nextItem.name !== previousItem.name) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private runMeasuredAction(label: string, action: () => void) {
+        if (!isSelectionPerfDebugEnabled()) {
+            action();
+            return;
+        }
+
+        const start = performance.now();
+        action();
+
+        requestAnimationFrame(() => {
+            const elapsed = performance.now() - start;
+            console.debug(`[selection-perf] ${label}: ${elapsed.toFixed(1)}ms`, {
+                selectionCount: this.selected.size,
+            });
+        });
+    }
+}
+
+const SelectionContext = createContext<SelectionStore | null>(null);
+
+function useSelectionStore() {
+    const store = useContext(SelectionContext);
+    if (!store) {
+        throw new Error("Selection hooks must be used within a SelectionProvider");
+    }
+
+    return store;
+}
+
+export function useSelectionActions() {
+    return useSelectionStore().actions;
+}
+
+export function useSelectionCount() {
+    const store = useSelectionStore();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribeSelectionCount(listener), [store]),
+        useCallback(() => store.getSelectionCount(), [store]),
+        () => EMPTY_COUNT,
     );
 }
+
+export function useSelectedItems() {
+    const store = useSelectionStore();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribeSelection(listener), [store]),
+        useCallback(() => store.getSelectedItemsSnapshot(), [store]),
+        () => EMPTY_SELECTED_ITEMS_SNAPSHOT,
+    );
+}
+
+export function useIsItemSelected(id: string) {
+    const store = useSelectionStore();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribeItem(id, listener), [store, id]),
+        useCallback(() => store.isSelected(id), [store, id]),
+        () => EMPTY_SELECTED,
+    );
+}
+
+export function useIsItemInMultiSelection(id: string) {
+    const store = useSelectionStore();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribeItem(id, listener), [store, id]),
+        useCallback(() => store.isItemInMultiSelection(id), [store, id]),
+        () => EMPTY_MULTI_SELECTED,
+    );
+}
+
+export { SelectionContext };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,15 @@ const typeCheckedConfigs = tseslint.configs.recommendedTypeChecked.map((config) 
 module.exports = [
     ...customConfig,
     {
-        ignores: ["**/dist/**", "**/.output/**", "**/.vinxi/**", "**/.tanstack/**", "**/.turbo/**", "**/node_modules/**"],
+        ignores: [
+            "**/dist/**",
+            "**/.output/**",
+            "**/.vinxi/**",
+            "**/.tanstack/**",
+            "**/routeTree.gen.ts",
+            "**/.turbo/**",
+            "**/node_modules/**",
+        ],
     },
     {
         settings: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.132.0
         version: 1.158.3(crossws@0.4.4(srvx@0.10.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.158.1(@tanstack/react-router@1.158.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
@@ -2112,6 +2115,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.18':
+    resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-cli@1.158.1':
     resolution: {integrity: sha512-TaGETPw+EdoKCN+1Jadse08F1KWWiBCFivuXeLauIkK3yN9I4B6y4Elvu/hgV3ZAS9aL/kA4CMoevYTvb03+fw==}
     engines: {node: '>=12'}
@@ -2174,6 +2183,9 @@ packages:
 
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
+
+  '@tanstack/virtual-core@3.13.18':
+    resolution: {integrity: sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==}
 
   '@tanstack/virtual-file-routes@1.154.7':
     resolution: {integrity: sha512-cHHDnewHozgjpI+MIVp9tcib6lYEQK5MyUr0ChHpHFGBl8Xei55rohFK0I0ve/GKoHeioaK42Smd8OixPp6CTg==}
@@ -6575,6 +6587,12 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
+  '@tanstack/react-virtual@3.13.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.18
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@tanstack/router-cli@1.158.1':
     dependencies:
       '@tanstack/router-generator': 1.158.1
@@ -6699,6 +6717,8 @@ snapshots:
       '@tanstack/router-core': 1.158.1
 
   '@tanstack/store@0.8.0': {}
+
+  '@tanstack/virtual-core@3.13.18': {}
 
   '@tanstack/virtual-file-routes@1.154.7': {}
 


### PR DESCRIPTION
## Summary
Selecting files and folders in large directories was noticeably laggy, and the page rendered more DOM than needed. This change improves responsiveness by virtualizing folder/file lists and by making selection updates granular so only affected items re-render.

## User Impact
Before this change, users navigating large folders could experience stutter when selecting items, especially with range/multi-selection. Context-menu actions also had to infer multi-selection state from broader component re-renders, which increased UI work and made behavior harder to keep consistent.

After this change, selection interactions are faster and scale better with item count, while file/folder context-menu actions resolve targets from the current selection state in a predictable way.

## Root Cause
The folder page rendered full folder/file collections in both grid and list modes, and selection state changes propagated broadly through React context consumers. That combination caused unnecessary re-renders and expensive layout/paint work on each selection toggle.

## Fix
- Added `@tanstack/react-virtual` and introduced `VirtualizedItemSection` for both folder and file sections.
- Virtualized rendering supports both grid and list layouts with dynamic measurement and overscan.
- Refactored selection state into a `SelectionStore` that uses `useSyncExternalStore` subscriptions for:
  - selection count,
  - full selected snapshot,
  - per-item selected state,
  - per-item multi-selection membership.
- Kept selection store instance stable in `SelectionProvider` and synchronized source data without recreating the store.
- Updated folder/file row and card composition to memoized selectable wrappers so only relevant items update on selection changes.
- Updated context menu and selection-toolbar action targeting to resolve from current selected items, with rename limited to single-item cases.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
