### PR TITLE
fix(nova): [codex] deselect selection on non-item clicks in folder contents

### DIFF
--- a/apps/nova/src/features/folder/components/file-card.tsx
+++ b/apps/nova/src/features/folder/components/file-card.tsx
@@ -87,6 +87,7 @@ export function FileCard({ id, fileName, folderId, selected, onClick, onContextM
 
     return (
         <div
+            data-selection-item="true"
             onClick={onClick}
             onContextMenu={onContextMenu}
             onDoubleClick={openPreview}

--- a/apps/nova/src/features/folder/components/file-row.tsx
+++ b/apps/nova/src/features/folder/components/file-row.tsx
@@ -80,6 +80,7 @@ export function FileRow({ id, fileName, folderId, selected, onClick, onContextMe
 
     return (
         <div
+            data-selection-item="true"
             onClick={onClick}
             onContextMenu={onContextMenu}
             onDoubleClick={openPreview}

--- a/apps/nova/src/features/folder/components/folder-card.tsx
+++ b/apps/nova/src/features/folder/components/folder-card.tsx
@@ -31,6 +31,7 @@ export function FolderCard({ id, name, selected, onClick, onContextMenu }: Folde
 
     return (
         <div
+            data-selection-item="true"
             onClick={onClick}
             onContextMenu={onContextMenu}
             onDoubleClick={openFolder}

--- a/apps/nova/src/features/folder/components/folder-row.tsx
+++ b/apps/nova/src/features/folder/components/folder-row.tsx
@@ -31,6 +31,7 @@ export function FolderRow({ id, name, selected, onClick, onContextMenu }: Folder
 
     return (
         <div
+            data-selection-item="true"
             onClick={onClick}
             onContextMenu={onContextMenu}
             onDoubleClick={openFolder}

--- a/apps/nova/src/routes/_authed.folder.$folderId.tsx
+++ b/apps/nova/src/routes/_authed.folder.$folderId.tsx
@@ -521,9 +521,16 @@ function FolderPageContent({
     // ── Background click to clear selection ───────────────────
     const handleBackgroundClick = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
-            if (e.target === e.currentTarget && selectionCount > 0) {
-                clearSelection();
+            if (selectionCount === 0) {
+                return;
             }
+
+            const target = e.target as HTMLElement | null;
+            if (target?.closest('[data-selection-item="true"]')) {
+                return;
+            }
+
+            clearSelection();
         },
         [selectionCount, clearSelection],
     );


### PR DESCRIPTION
## Issue
In the folder contents view, users can select files and folders, but clicking non-item UI surfaces inside the contents region (such as section headers, virtualized spacing, and layout wrappers) did not reliably clear selection. This made multi-select state feel sticky and increased accidental bulk actions when users expected a neutral click to reset selection.

## Cause and User Impact
The deselection handler only cleared selection when `event.target === event.currentTarget`. With virtualization and nested wrappers, many non-item clicks target descendant elements instead of the exact container node, so the guard prevented deselection even though users clicked outside any file/folder row or card.

## Root Cause
Selection-clear behavior was coupled to a strict DOM equality check that does not hold in the virtualized layout structure. The logic lacked a positive way to detect whether a click originated from an actual selectable item root.

## Fix
The fix introduces an explicit DOM marker on selectable item roots (`data-selection-item="true"`) for file rows, folder rows, file cards, and folder cards. The folder-page background click handler now:

- Returns early when nothing is selected.
- Checks `target.closest('[data-selection-item="true"]')`.
- Clears selection only when the click originated outside selectable item roots.

This preserves existing item-click selection behavior while making non-item clicks within the folder contents area consistently clear selection. Scope remains intentionally limited to the list/content area and does not alter header/toolbar behavior.

## Validation
Validation was run in-repo with:

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run prettier:write`

All commands completed successfully.
