### PR TITLE
fix(nova): [codex] align overlay portal mounting with tanstack shadcn guidance

### DIFF
--- a/apps/nova/src/components/ui/context-menu.tsx
+++ b/apps/nova/src/components/ui/context-menu.tsx
@@ -2,6 +2,8 @@ import { ContextMenu as BaseContextMenu } from "@base-ui/react/context-menu";
 import { Menu } from "@base-ui/react/menu";
 import type { ReactNode } from "react";
 
+import { getPortalRoot } from "@/lib/portal-root";
+
 type ContextMenuProps = {
     children: ReactNode;
     trigger: ReactNode;
@@ -11,7 +13,7 @@ export function ContextMenu({ children, trigger }: ContextMenuProps) {
     return (
         <BaseContextMenu.Root>
             <BaseContextMenu.Trigger className="contents">{trigger}</BaseContextMenu.Trigger>
-            <Menu.Portal>
+            <Menu.Portal container={getPortalRoot()}>
                 <Menu.Positioner className="z-[100]" sideOffset={6}>
                     <Menu.Popup className="border-border-bright bg-surface/95 min-w-[200px] origin-[var(--transform-origin)] rounded-lg border p-1 shadow-2xl shadow-black/50 backdrop-blur-xl transition-all duration-100 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
                         {children}

--- a/apps/nova/src/components/ui/dialog.tsx
+++ b/apps/nova/src/components/ui/dialog.tsx
@@ -1,6 +1,8 @@
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import type { ReactNode } from "react";
 
+import { getPortalRoot } from "@/lib/portal-root";
+
 type DialogProps = {
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -24,7 +26,7 @@ type DialogContentProps = {
 
 export function DialogContent({ children, className, title, description }: DialogContentProps) {
     return (
-        <BaseDialog.Portal>
+        <BaseDialog.Portal container={getPortalRoot()}>
             <BaseDialog.Backdrop className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
             <BaseDialog.Popup
                 className={`border-border bg-surface fixed top-1/2 left-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl border shadow-2xl shadow-black/40 transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 ${className ?? ""}`}

--- a/apps/nova/src/components/ui/tooltip.tsx
+++ b/apps/nova/src/components/ui/tooltip.tsx
@@ -1,6 +1,8 @@
 import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import type { ReactNode } from "react";
 
+import { getPortalRoot } from "@/lib/portal-root";
+
 type TooltipProps = {
     children: ReactNode;
     content: string;
@@ -14,7 +16,7 @@ export function Tooltip({ children, content, side = "top" }: TooltipProps) {
                 <BaseTooltip.Trigger className="contents" render={<span />}>
                     {children}
                 </BaseTooltip.Trigger>
-                <BaseTooltip.Portal>
+                <BaseTooltip.Portal container={getPortalRoot()}>
                     <BaseTooltip.Positioner side={side} sideOffset={8}>
                         <BaseTooltip.Popup className="bg-surface-raised border-border-bright text-text rounded-lg border px-3 py-2 text-xs shadow-lg shadow-black/30 transition-opacity duration-100 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
                             {content}

--- a/apps/nova/src/lib/portal-root.ts
+++ b/apps/nova/src/lib/portal-root.ts
@@ -1,0 +1,16 @@
+const PORTAL_ROOT_ID = "portal-root";
+
+let cachedPortalRoot: HTMLElement | null = null;
+
+export function getPortalRoot() {
+    if (typeof document === "undefined") {
+        return undefined;
+    }
+
+    if (cachedPortalRoot && document.body.contains(cachedPortalRoot)) {
+        return cachedPortalRoot;
+    }
+
+    cachedPortalRoot = document.getElementById(PORTAL_ROOT_ID);
+    return cachedPortalRoot ?? undefined;
+}

--- a/apps/nova/src/routes/__root.tsx
+++ b/apps/nova/src/routes/__root.tsx
@@ -76,6 +76,8 @@ function RootError(props: { error: unknown; reset: () => void }) {
 }
 
 function RootNotFound() {
+    const router = useRouter();
+
     return (
         <div className="flex min-h-screen items-center justify-center p-6">
             <div className="border-border bg-surface w-full max-w-lg space-y-4 rounded-xl border p-7 text-center">
@@ -84,7 +86,12 @@ function RootNotFound() {
                     <h1 className="text-text text-lg font-semibold">Page not found</h1>
                     <p className="text-text-muted mt-1.5 text-sm">The resource you requested does not exist.</p>
                 </div>
-                <Button variant="primary" onClick={() => (window.location.href = "/")}>
+                <Button
+                    variant="primary"
+                    onClick={() => {
+                        void router.navigate({ to: "/" });
+                    }}
+                >
                     Go to Files
                 </Button>
             </div>
@@ -99,7 +106,8 @@ function RootDocument({ children }: { children: React.ReactNode }) {
                 <HeadContent />
             </head>
             <body>
-                {children}
+                <div id="root-content">{children}</div>
+                <div id="portal-root" />
                 <Scripts />
             </body>
         </html>


### PR DESCRIPTION
## Issue
TanStack Start's integration guidance for shadcn-style overlays recommends a stable portal root and router-native navigation to avoid animation glitches and unnecessary reloads.

In Nova, overlay primitives (dialog, context menu, tooltip) were using default portal behavior to `document.body`, and the root document did not define a dedicated portal host. The not-found CTA also used `window.location`, which forced a full page reload.

## User Impact
Users could experience inconsistent overlay stacking/animation behavior during route transitions, and the 404 recovery action performed a hard reload instead of client-side navigation.

## Root Cause
The app shell lacked the explicit `root-content` + `portal-root` DOM structure recommended for routed overlay behavior, and Base UI portal wrappers were not pinned to a stable mount container.

## Fix
- Added `#root-content` and `#portal-root` to the root document structure.
- Added a shared SSR-safe portal resolver (`getPortalRoot`) with light caching.
- Updated dialog portals to mount in `#portal-root`.
- Updated context menu portals to mount in `#portal-root`.
- Updated tooltip portals to mount in `#portal-root`.
- Replaced 404 `window.location` navigation with `router.navigate` to preserve SPA behavior.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run prettier:write`
