### PR TITLE
[codex] feat(folder,recycle-bin): add batch move/delete and recycle-bin bulk ops

### DIFF
--- a/apps/nova/src/features/folder/api.ts
+++ b/apps/nova/src/features/folder/api.ts
@@ -100,9 +100,7 @@ const mutateFolderResponseSchema = z.object({
     parentFolderId: z.string().nullable(),
 });
 
-const batchItemTypeSchema = z.enum(["FILE", "FOLDER"]);
-const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
-const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+const batchOperationStatusSchema = z.enum(["success", "failed"]);
 
 const batchItemIdsInputSchema = z
     .object({
@@ -128,39 +126,18 @@ const batchOperationSummarySchema = z.object({
     total: z.number().int(),
     succeeded: z.number().int(),
     failed: z.number().int(),
-    skipped: z.number().int(),
-});
-
-const batchMoveResultSchema = z.object({
-    itemType: batchItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    destinationFolderId: z.string().optional(),
-});
-
-const batchDeleteResultSchema = z.object({
-    itemType: batchItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    parentFolderId: z.string().nullable().optional(),
 });
 
 const batchMoveItemsResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchMoveResultSchema),
 });
 
 const batchDeleteItemsResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchDeleteResultSchema),
 });
 
 const moveFolderInputSchema = z.object({

--- a/apps/nova/src/features/folder/api.ts
+++ b/apps/nova/src/features/folder/api.ts
@@ -100,6 +100,69 @@ const mutateFolderResponseSchema = z.object({
     parentFolderId: z.string().nullable(),
 });
 
+const batchItemTypeSchema = z.enum(["FILE", "FOLDER"]);
+const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
+const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+
+const batchItemIdsInputSchema = z
+    .object({
+        fileIds: z.array(z.string().min(1)).max(500).optional(),
+        folderIds: z.array(z.string().min(1)).max(500).optional(),
+    })
+    .superRefine((value, context) => {
+        const totalIds = (value.fileIds?.length ?? 0) + (value.folderIds?.length ?? 0);
+        if (totalIds === 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "At least one fileId or folderId is required",
+                path: ["fileIds"],
+            });
+        }
+    });
+
+const batchMoveItemsInputSchema = batchItemIdsInputSchema.extend({
+    destinationFolderId: z.string().min(1),
+});
+
+const batchOperationSummarySchema = z.object({
+    total: z.number().int(),
+    succeeded: z.number().int(),
+    failed: z.number().int(),
+    skipped: z.number().int(),
+});
+
+const batchMoveResultSchema = z.object({
+    itemType: batchItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    destinationFolderId: z.string().optional(),
+});
+
+const batchDeleteResultSchema = z.object({
+    itemType: batchItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    parentFolderId: z.string().nullable().optional(),
+});
+
+const batchMoveItemsResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchMoveResultSchema),
+});
+
+const batchDeleteItemsResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchDeleteResultSchema),
+});
+
 const moveFolderInputSchema = z.object({
     folderId: z.string().min(1),
     destinationFolderId: z.string().min(1),
@@ -142,6 +205,10 @@ export type FolderContents = z.infer<typeof folderContentsSchema>;
 export type CreateFolderInput = z.infer<typeof createFolderInputSchema>;
 export type DestinationFoldersInput = z.infer<typeof destinationFoldersInputSchema>;
 export type FolderDestinationChildren = z.infer<typeof folderDestinationChildrenResponseSchema>;
+export type BatchMoveItemsInput = z.infer<typeof batchMoveItemsInputSchema>;
+export type BatchDeleteItemsInput = z.infer<typeof batchItemIdsInputSchema>;
+export type BatchMoveItemsResponse = z.infer<typeof batchMoveItemsResponseSchema>;
+export type BatchDeleteItemsResponse = z.infer<typeof batchDeleteItemsResponseSchema>;
 
 export type GetFolderContentsOptions = {
     limit?: number;
@@ -177,6 +244,31 @@ export const moveFolder = async (input: z.infer<typeof moveFolderInputSchema>) =
     return patchJson(`/v1/folders/${encodeURIComponent(body.folderId)}`, mutateFolderResponseSchema, {
         body: {
             destinationFolderId: body.destinationFolderId,
+        },
+        headers: await createCsrfHeaders(),
+    });
+};
+
+export const batchMoveItems = async (input: BatchMoveItemsInput) => {
+    const body = batchMoveItemsInputSchema.parse(input);
+
+    return postJson("/v1/folders/batch/move", batchMoveItemsResponseSchema, {
+        body: {
+            destinationFolderId: body.destinationFolderId,
+            fileIds: body.fileIds,
+            folderIds: body.folderIds,
+        },
+        headers: await createCsrfHeaders(),
+    });
+};
+
+export const batchDeleteItems = async (input: BatchDeleteItemsInput) => {
+    const body = batchItemIdsInputSchema.parse(input);
+
+    return postJson("/v1/folders/batch/delete", batchDeleteItemsResponseSchema, {
+        body: {
+            fileIds: body.fileIds,
+            folderIds: body.folderIds,
         },
         headers: await createCsrfHeaders(),
     });

--- a/apps/nova/src/features/folder/components/selection-toolbar.tsx
+++ b/apps/nova/src/features/folder/components/selection-toolbar.tsx
@@ -18,20 +18,13 @@ import { useSelectedItems, useSelectionActions, type SelectionItem } from "@/fea
 import { toFileRouteId } from "@/lib/file-id";
 
 type SelectionToolbarProps = {
-    onDeleteFiles: (fileIds: string[]) => Promise<void>;
-    onDeleteFolders: (folderIds: string[]) => Promise<void>;
+    onDeleteSelection: (input: { fileIds: string[]; folderIds: string[] }) => Promise<void>;
     onShowInfo: (item: SelectionItem) => void;
     onRename: (item: SelectionItem) => void;
     onMove: (items: SelectionItem[]) => void;
 };
 
-export function SelectionToolbar({
-    onDeleteFiles,
-    onDeleteFolders,
-    onShowInfo,
-    onRename,
-    onMove,
-}: SelectionToolbarProps) {
+export function SelectionToolbar({ onDeleteSelection, onShowInfo, onRename, onMove }: SelectionToolbarProps) {
     const { selected, selectedFiles, selectedFolders, selectionCount } = useSelectedItems();
     const { clearSelection } = useSelectionActions();
     const { addToast } = useToast();
@@ -83,12 +76,7 @@ export function SelectionToolbar({
         const fileIds = selectedFiles.map((f) => f.id);
         const folderIds = selectedFolders.map((f) => f.id);
 
-        if (folderIds.length > 0) {
-            await onDeleteFolders(folderIds);
-        }
-        if (fileIds.length > 0) {
-            await onDeleteFiles(fileIds);
-        }
+        await onDeleteSelection({ fileIds, folderIds });
 
         clearSelection();
     };

--- a/apps/nova/src/features/recycle-bin/api.ts
+++ b/apps/nova/src/features/recycle-bin/api.ts
@@ -94,8 +94,7 @@ const permanentlyDeleteResponseSchema = z.object({
     purgedFolders: z.number().int(),
 });
 
-const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
-const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+const batchOperationStatusSchema = z.enum(["success", "failed"]);
 
 const batchItemIdsInputSchema = z
     .object({
@@ -121,41 +120,18 @@ const batchOperationSummarySchema = z.object({
     total: z.number().int(),
     succeeded: z.number().int(),
     failed: z.number().int(),
-    skipped: z.number().int(),
-});
-
-const batchRestoreResultSchema = z.object({
-    itemType: recycleItemTypeEnum,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    parentFolderId: z.string().nullable().optional(),
-    restoredCount: z.number().int().optional(),
-});
-
-const batchPermanentlyDeleteResultSchema = z.object({
-    itemType: recycleItemTypeEnum,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    purgedFiles: z.number().int().optional(),
-    purgedFolders: z.number().int().optional(),
 });
 
 const batchRestoreResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchRestoreResultSchema),
 });
 
 const batchPermanentlyDeleteResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchPermanentlyDeleteResultSchema),
 });
 
 const emptyRecycleBinInputSchema = z.object({

--- a/apps/server/src/systems/folder/folder.handlers.ts
+++ b/apps/server/src/systems/folder/folder.handlers.ts
@@ -5,6 +5,8 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { displayOrders, files, folders, users } from "@/db/schema";
 
 import type {
+    BatchDeleteItemsInput,
+    BatchMoveItemsInput,
     CreateFolderInput,
     FolderParams,
     GetFolderChildrenQuery,
@@ -14,9 +16,92 @@ import type {
 
 type ResolvedSortType = "NAME" | "DATE_CREATED" | "SIZE";
 type ResolvedSortOrder = "ASC" | "DESC";
+type BatchItemType = "FILE" | "FOLDER";
+type BatchItemOutcome = "SUCCESS" | "FAILED" | "SKIPPED";
+type BatchOperationStatus = "success" | "partial_success" | "failed";
+
+type BatchOperationSummary = {
+    total: number;
+    succeeded: number;
+    failed: number;
+    skipped: number;
+};
+
+type BatchMoveResult = {
+    itemType: BatchItemType;
+    itemId: string;
+    outcome: BatchItemOutcome;
+    message: string;
+    code?: string;
+    destinationFolderId?: string;
+};
+
+type BatchDeleteResult = {
+    itemType: BatchItemType;
+    itemId: string;
+    outcome: BatchItemOutcome;
+    message: string;
+    code?: string;
+    parentFolderId?: string | null;
+};
 
 const DEFAULT_SORT_TYPE: ResolvedSortType = "NAME";
 const DEFAULT_SORT_ORDER: ResolvedSortOrder = "ASC";
+
+const dedupeIds = (ids: string[] | undefined) => {
+    return Array.from(new Set(ids ?? []));
+};
+
+const summarizeBatchResults = <T extends { outcome: BatchItemOutcome }>(results: T[]): BatchOperationSummary => {
+    let succeeded = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const result of results) {
+        if (result.outcome === "SUCCESS") {
+            succeeded += 1;
+            continue;
+        }
+
+        if (result.outcome === "FAILED") {
+            failed += 1;
+            continue;
+        }
+
+        skipped += 1;
+    }
+
+    return {
+        total: results.length,
+        succeeded,
+        failed,
+        skipped,
+    };
+};
+
+const resolveBatchStatus = (summary: BatchOperationSummary): BatchOperationStatus => {
+    if (summary.failed === 0) {
+        return "success";
+    }
+
+    if (summary.succeeded === 0 && summary.skipped === 0) {
+        return "failed";
+    }
+
+    return "partial_success";
+};
+
+const buildBatchMessage = (operationLabel: string, status: BatchOperationStatus, summary: BatchOperationSummary) => {
+    if (status === "success") {
+        return `${operationLabel} completed successfully`;
+    }
+
+    if (status === "failed") {
+        return `${operationLabel} failed`;
+    }
+
+    return `${operationLabel} completed with partial success (${summary.failed} failed)`;
+};
 
 const getFolderOrderBy = (sortType: ResolvedSortType, sortOrder: ResolvedSortOrder) => {
     const direction = sortOrder === "ASC" ? asc : desc;
@@ -407,6 +492,425 @@ export async function createFolderHandler(
     }
 
     return reply.code(201).send({ id: folder.id });
+}
+
+export async function batchMoveItemsHandler(
+    this: FastifyInstance,
+    request: FastifyRequest<{ Body: BatchMoveItemsInput }>,
+    reply: FastifyReply,
+) {
+    const userId = request.user?.id;
+    if (!userId) {
+        return reply.code(401).send({ message: "Unauthorized" });
+    }
+
+    const destinationFolderId = request.body.destinationFolderId;
+    const folderIds = dedupeIds(request.body.folderIds);
+    const fileIds = dedupeIds(request.body.fileIds);
+    const results: BatchMoveResult[] = [];
+
+    const [destinationFolder] = await this.db
+        .select({ id: folders.id, ownerId: folders.ownerId, folderPath: folders.folderPath })
+        .from(folders)
+        .where(and(eq(folders.id, destinationFolderId), isNull(folders.deletedAt)))
+        .limit(1);
+
+    if (!destinationFolder || destinationFolder.ownerId !== userId) {
+        const failureMessage = !destinationFolder
+            ? "Destination folder not found"
+            : "You do not have permission to move items to this location";
+        const failureCode = !destinationFolder ? "DESTINATION_FOLDER_NOT_FOUND" : "FORBIDDEN_DESTINATION_FOLDER";
+
+        for (const folderId of folderIds) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: failureMessage,
+                code: failureCode,
+            });
+        }
+
+        for (const fileId of fileIds) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "FAILED",
+                message: failureMessage,
+                code: failureCode,
+            });
+        }
+
+        const summary = summarizeBatchResults(results);
+        const status = resolveBatchStatus(summary);
+        return reply.code(200).send({
+            status,
+            message: buildBatchMessage("Batch move", status, summary),
+            summary,
+            results,
+        });
+    }
+
+    for (const folderId of folderIds) {
+        const [sourceFolder] = await this.db
+            .select({
+                id: folders.id,
+                ownerId: folders.ownerId,
+                type: folders.type,
+                parentFolderId: folders.parentFolderId,
+                folderPath: folders.folderPath,
+                deletedAt: folders.deletedAt,
+            })
+            .from(folders)
+            .where(eq(folders.id, folderId))
+            .limit(1);
+
+        if (!sourceFolder) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Folder not found",
+                code: "FOLDER_NOT_FOUND",
+            });
+            continue;
+        }
+
+        if (sourceFolder.ownerId !== userId) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "You do not have permission to move this folder",
+                code: "FORBIDDEN_FOLDER",
+            });
+            continue;
+        }
+
+        if (sourceFolder.deletedAt !== null) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "SKIPPED",
+                message: "Folder is already in recycle bin",
+                code: "FOLDER_ALREADY_DELETED",
+            });
+            continue;
+        }
+
+        if (sourceFolder.type === "ROOT") {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Root folder cannot be moved",
+                code: "ROOT_FOLDER_NOT_MOVABLE",
+            });
+            continue;
+        }
+
+        if (sourceFolder.parentFolderId === destinationFolderId) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "SKIPPED",
+                message: "Folder already in destination folder",
+                code: "ALREADY_IN_DESTINATION",
+                destinationFolderId,
+            });
+            continue;
+        }
+
+        if (folderId === destinationFolderId) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Folder cannot be moved into itself",
+                code: "SAME_AS_DESTINATION",
+            });
+            continue;
+        }
+
+        if (
+            destinationFolder.folderPath === sourceFolder.folderPath ||
+            destinationFolder.folderPath.startsWith(`${sourceFolder.folderPath}/`)
+        ) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Folder cannot be moved into its own descendant",
+                code: "DESTINATION_IS_DESCENDANT",
+            });
+            continue;
+        }
+
+        const newSourcePath = buildFolderPath(destinationFolder.folderPath, sourceFolder.id);
+
+        await this.db.transaction(async (tx) => {
+            await tx.update(folders).set({ parentFolderId: destinationFolderId }).where(eq(folders.id, folderId));
+            await tx.execute(sql`
+                update "Folders"
+                set "folderPath" = ${newSourcePath} || substring("folderPath" from ${sourceFolder.folderPath.length + 1})
+                where "ownerId" = ${userId}
+                  and ("folderPath" = ${sourceFolder.folderPath} or "folderPath" like ${`${sourceFolder.folderPath}/%`})
+            `);
+        });
+
+        results.push({
+            itemType: "FOLDER",
+            itemId: folderId,
+            outcome: "SUCCESS",
+            message: "Folder moved successfully",
+            destinationFolderId,
+        });
+    }
+
+    for (const fileId of fileIds) {
+        const [fileDetails] = await this.db
+            .select({
+                id: files.id,
+                ownerId: files.ownerId,
+                parentId: files.parentId,
+                deletedAt: files.deletedAt,
+            })
+            .from(files)
+            .where(eq(files.id, fileId))
+            .limit(1);
+
+        if (!fileDetails) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "FAILED",
+                message: "File not found",
+                code: "FILE_NOT_FOUND",
+            });
+            continue;
+        }
+
+        if (fileDetails.ownerId !== userId) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "FAILED",
+                message: "You do not have permission to move this file",
+                code: "FORBIDDEN_FILE",
+            });
+            continue;
+        }
+
+        if (fileDetails.deletedAt !== null) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "SKIPPED",
+                message: "File is already in recycle bin",
+                code: "FILE_ALREADY_DELETED",
+            });
+            continue;
+        }
+
+        if (fileDetails.parentId === destinationFolderId) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "SKIPPED",
+                message: "File already in destination folder",
+                code: "ALREADY_IN_DESTINATION",
+                destinationFolderId,
+            });
+            continue;
+        }
+
+        await this.db.update(files).set({ parentId: destinationFolderId }).where(eq(files.id, fileId));
+
+        results.push({
+            itemType: "FILE",
+            itemId: fileId,
+            outcome: "SUCCESS",
+            message: "File moved successfully",
+            destinationFolderId,
+        });
+    }
+
+    const summary = summarizeBatchResults(results);
+    const status = resolveBatchStatus(summary);
+
+    return reply.code(200).send({
+        status,
+        message: buildBatchMessage("Batch move", status, summary),
+        summary,
+        results,
+    });
+}
+
+export async function batchDeleteItemsHandler(
+    this: FastifyInstance,
+    request: FastifyRequest<{ Body: BatchDeleteItemsInput }>,
+    reply: FastifyReply,
+) {
+    const userId = request.user?.id;
+    if (!userId) {
+        return reply.code(401).send({ message: "Unauthorized" });
+    }
+
+    const folderIds = dedupeIds(request.body.folderIds);
+    const fileIds = dedupeIds(request.body.fileIds);
+    const results: BatchDeleteResult[] = [];
+
+    for (const folderId of folderIds) {
+        const [folder] = await this.db
+            .select({
+                id: folders.id,
+                ownerId: folders.ownerId,
+                type: folders.type,
+                parentFolderId: folders.parentFolderId,
+                deletedAt: folders.deletedAt,
+            })
+            .from(folders)
+            .where(eq(folders.id, folderId))
+            .limit(1);
+
+        if (!folder) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Folder not found",
+                code: "FOLDER_NOT_FOUND",
+            });
+            continue;
+        }
+
+        if (folder.ownerId !== userId) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "You do not have permission to delete this folder",
+                code: "FORBIDDEN_FOLDER",
+            });
+            continue;
+        }
+
+        if (folder.deletedAt !== null) {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "SKIPPED",
+                message: "Folder is already in recycle bin",
+                code: "FOLDER_ALREADY_DELETED",
+                parentFolderId: folder.parentFolderId,
+            });
+            continue;
+        }
+
+        if (folder.type === "ROOT") {
+            results.push({
+                itemType: "FOLDER",
+                itemId: folderId,
+                outcome: "FAILED",
+                message: "Root folder cannot be deleted",
+                code: "ROOT_FOLDER_NOT_DELETABLE",
+                parentFolderId: folder.parentFolderId,
+            });
+            continue;
+        }
+
+        const deletedAt = new Date();
+        const subtreeFolderIds = await collectFolderSubtreeIds(this, userId, folderId);
+
+        await this.db.transaction(async (tx) => {
+            await tx
+                .update(files)
+                .set({ deletedAt })
+                .where(
+                    and(eq(files.ownerId, userId), inArray(files.parentId, subtreeFolderIds), isNull(files.deletedAt)),
+                );
+
+            await tx
+                .update(folders)
+                .set({ deletedAt })
+                .where(
+                    and(eq(folders.ownerId, userId), inArray(folders.id, subtreeFolderIds), isNull(folders.deletedAt)),
+                );
+
+            await tx.delete(displayOrders).where(inArray(displayOrders.folderId, subtreeFolderIds));
+        });
+
+        results.push({
+            itemType: "FOLDER",
+            itemId: folderId,
+            outcome: "SUCCESS",
+            message: "Folder moved to recycle bin",
+            parentFolderId: folder.parentFolderId,
+        });
+    }
+
+    for (const fileId of fileIds) {
+        const [fileDetails] = await this.db
+            .select({ id: files.id, ownerId: files.ownerId, parentId: files.parentId, deletedAt: files.deletedAt })
+            .from(files)
+            .where(eq(files.id, fileId))
+            .limit(1);
+
+        if (!fileDetails) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "FAILED",
+                message: "File not found",
+                code: "FILE_NOT_FOUND",
+            });
+            continue;
+        }
+
+        if (fileDetails.ownerId !== userId) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "FAILED",
+                message: "You do not have permission to delete this file",
+                code: "FORBIDDEN_FILE",
+                parentFolderId: fileDetails.parentId,
+            });
+            continue;
+        }
+
+        if (fileDetails.deletedAt !== null) {
+            results.push({
+                itemType: "FILE",
+                itemId: fileId,
+                outcome: "SKIPPED",
+                message: "File is already in recycle bin",
+                code: "FILE_ALREADY_DELETED",
+                parentFolderId: fileDetails.parentId,
+            });
+            continue;
+        }
+
+        await this.db.update(files).set({ deletedAt: new Date() }).where(eq(files.id, fileId));
+
+        results.push({
+            itemType: "FILE",
+            itemId: fileId,
+            outcome: "SUCCESS",
+            message: "File moved to recycle bin",
+            parentFolderId: fileDetails.parentId,
+        });
+    }
+
+    const summary = summarizeBatchResults(results);
+    const status = resolveBatchStatus(summary);
+
+    return reply.code(200).send({
+        status,
+        message: buildBatchMessage("Batch delete", status, summary),
+        summary,
+        results,
+    });
 }
 
 export async function patchFolderHandler(

--- a/apps/server/src/systems/folder/folder.routes.ts
+++ b/apps/server/src/systems/folder/folder.routes.ts
@@ -2,6 +2,8 @@
 import type { FastifyInstance } from "fastify";
 
 import {
+    batchDeleteItemsHandler,
+    batchMoveItemsHandler,
     createFolderHandler,
     deleteFolderHandler,
     getDetailsHandler,
@@ -62,6 +64,32 @@ async function folderRouter(server: FastifyInstance) {
             response: { 201: $ref("createFolderResponseSchema") },
         },
         handler: createFolderHandler,
+    });
+
+    server.route({
+        method: "POST",
+        url: "/folders/batch/move",
+        onRequest: [server.optionalAuthenticate],
+        preValidation: [server.authenticate],
+        preHandler: [server.requireCsrf],
+        schema: {
+            body: $ref("batchMoveItemsSchema"),
+            response: { 200: $ref("batchMoveItemsResponseSchema") },
+        },
+        handler: batchMoveItemsHandler,
+    });
+
+    server.route({
+        method: "POST",
+        url: "/folders/batch/delete",
+        onRequest: [server.optionalAuthenticate],
+        preValidation: [server.authenticate],
+        preHandler: [server.requireCsrf],
+        schema: {
+            body: $ref("batchItemIdsSchema"),
+            response: { 200: $ref("batchDeleteItemsResponseSchema") },
+        },
+        handler: batchDeleteItemsHandler,
     });
 
     server.route({

--- a/apps/server/src/systems/folder/folder.schemas.ts
+++ b/apps/server/src/systems/folder/folder.schemas.ts
@@ -116,6 +116,89 @@ const mutateFolderResponseSchema = z.object({
     parentFolderId: z.string().nullable(),
 });
 
+const batchItemTypeSchema = z.enum(["FILE", "FOLDER"]);
+const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
+const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+
+const batchItemIdArraySchema = z.array(z.string()).max(500);
+
+const batchItemIdsSchema = z
+    .object({
+        fileIds: batchItemIdArraySchema.optional(),
+        folderIds: batchItemIdArraySchema.optional(),
+    })
+    .strict()
+    .superRefine((value, context) => {
+        const totalIds = (value.fileIds?.length ?? 0) + (value.folderIds?.length ?? 0);
+        if (totalIds === 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "At least one fileId or folderId is required",
+                path: ["fileIds"],
+            });
+        }
+    });
+
+const batchMoveItemsSchema = z
+    .object({
+        destinationFolderId: z.string({
+            required_error: "Destination folder ID is required",
+            invalid_type_error: "Destination folder ID must be a string",
+        }),
+        fileIds: batchItemIdArraySchema.optional(),
+        folderIds: batchItemIdArraySchema.optional(),
+    })
+    .strict()
+    .superRefine((value, context) => {
+        const totalIds = (value.fileIds?.length ?? 0) + (value.folderIds?.length ?? 0);
+        if (totalIds === 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "At least one fileId or folderId is required",
+                path: ["fileIds"],
+            });
+        }
+    });
+
+const batchOperationSummarySchema = z.object({
+    total: z.number().int(),
+    succeeded: z.number().int(),
+    failed: z.number().int(),
+    skipped: z.number().int(),
+});
+
+const batchMoveResultSchema = z.object({
+    itemType: batchItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    destinationFolderId: z.string().optional(),
+});
+
+const batchDeleteResultSchema = z.object({
+    itemType: batchItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    parentFolderId: z.string().nullable().optional(),
+});
+
+const batchMoveItemsResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchMoveResultSchema),
+});
+
+const batchDeleteItemsResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchDeleteResultSchema),
+});
+
 const displayPreferencesResponseSchema = z.object({
     folderId: z.string(),
     displayType: z.enum(["GRID", "LIST"]),
@@ -134,6 +217,8 @@ export type GetFolderChildrenQuery = z.infer<typeof getFolderChildrenQuerySchema
 export type CreateFolderInput = z.infer<typeof createFolderSchema>;
 export type PatchFolderInput = z.infer<typeof patchFolderBodySchema>;
 export type PutDisplayPreferencesInput = z.infer<typeof putDisplayPreferencesSchema>;
+export type BatchMoveItemsInput = z.infer<typeof batchMoveItemsSchema>;
+export type BatchDeleteItemsInput = z.infer<typeof batchItemIdsSchema>;
 
 export const { schemas: folderSchemas, $ref } = buildJsonSchemas(
     {
@@ -146,6 +231,10 @@ export const { schemas: folderSchemas, $ref } = buildJsonSchemas(
         createFolderResponseSchema,
         patchFolderBodySchema,
         mutateFolderResponseSchema,
+        batchMoveItemsSchema,
+        batchMoveItemsResponseSchema,
+        batchItemIdsSchema,
+        batchDeleteItemsResponseSchema,
         displayPreferencesResponseSchema,
         putDisplayPreferencesSchema,
     },

--- a/apps/server/src/systems/folder/folder.schemas.ts
+++ b/apps/server/src/systems/folder/folder.schemas.ts
@@ -116,9 +116,7 @@ const mutateFolderResponseSchema = z.object({
     parentFolderId: z.string().nullable(),
 });
 
-const batchItemTypeSchema = z.enum(["FILE", "FOLDER"]);
-const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
-const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+const batchOperationStatusSchema = z.enum(["success", "failed"]);
 
 const batchItemIdArraySchema = z.array(z.string()).max(500);
 
@@ -164,39 +162,18 @@ const batchOperationSummarySchema = z.object({
     total: z.number().int(),
     succeeded: z.number().int(),
     failed: z.number().int(),
-    skipped: z.number().int(),
-});
-
-const batchMoveResultSchema = z.object({
-    itemType: batchItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    destinationFolderId: z.string().optional(),
-});
-
-const batchDeleteResultSchema = z.object({
-    itemType: batchItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    parentFolderId: z.string().nullable().optional(),
 });
 
 const batchMoveItemsResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchMoveResultSchema),
 });
 
 const batchDeleteItemsResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchDeleteResultSchema),
 });
 
 const displayPreferencesResponseSchema = z.object({

--- a/apps/server/src/systems/recycle-bin/recycle-bin.handlers.ts
+++ b/apps/server/src/systems/recycle-bin/recycle-bin.handlers.ts
@@ -1524,7 +1524,6 @@ export async function batchRestoreHandler(
                                 select 1
                                 from validated_roots as ancestor_root
                                 where ancestor_root."id" <> validated_roots."id"
-                                  and ancestor_root."rootDeletedAt" = validated_roots."rootDeletedAt"
                                   and validated_roots."oldPath" like ancestor_root."oldPath" || '/%'
                             )`
                                 : sql`true`
@@ -1628,7 +1627,6 @@ export async function batchRestoreHandler(
                                 select 1
                                 from validated_roots as ancestor_root
                                 where ancestor_root."id" <> validated_roots."id"
-                                  and ancestor_root."rootDeletedAt" = validated_roots."rootDeletedAt"
                                   and validated_roots."oldPath" like ancestor_root."oldPath" || '/%'
                             )`
                                 : sql`true`

--- a/apps/server/src/systems/recycle-bin/recycle-bin.routes.ts
+++ b/apps/server/src/systems/recycle-bin/recycle-bin.routes.ts
@@ -2,6 +2,8 @@
 import type { FastifyInstance } from "fastify";
 
 import {
+    batchPermanentlyDeleteHandler,
+    batchRestoreHandler,
     destinationFoldersHandler,
     emptyRecycleBinHandler,
     listRecycleBinHandler,
@@ -53,6 +55,19 @@ async function recycleBinRouter(server: FastifyInstance) {
     });
 
     server.route({
+        method: "POST",
+        url: "/items/batch/restore",
+        onRequest: [server.optionalAuthenticate],
+        preValidation: [server.authenticate],
+        preHandler: [server.requireCsrf],
+        schema: {
+            body: $ref("batchRestoreBodySchema"),
+            response: { 200: $ref("batchRestoreResponseSchema") },
+        },
+        handler: batchRestoreHandler,
+    });
+
+    server.route({
         method: "DELETE",
         url: "/items/:itemType/:itemId",
         onRequest: [server.optionalAuthenticate],
@@ -63,6 +78,19 @@ async function recycleBinRouter(server: FastifyInstance) {
             response: { 200: $ref("permanentlyDeleteResponseSchema") },
         },
         handler: permanentlyDeleteHandler,
+    });
+
+    server.route({
+        method: "POST",
+        url: "/items/batch/permanently-delete",
+        onRequest: [server.optionalAuthenticate],
+        preValidation: [server.authenticate],
+        preHandler: [server.requireCsrf],
+        schema: {
+            body: $ref("batchItemIdsSchema"),
+            response: { 200: $ref("batchPermanentlyDeleteResponseSchema") },
+        },
+        handler: batchPermanentlyDeleteHandler,
     });
 
     server.route({

--- a/apps/server/src/systems/recycle-bin/recycle-bin.schemas.ts
+++ b/apps/server/src/systems/recycle-bin/recycle-bin.schemas.ts
@@ -73,8 +73,7 @@ const permanentlyDeleteResponseSchema = z.object({
     purgedFolders: z.number().int(),
 });
 
-const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
-const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+const batchOperationStatusSchema = z.enum(["success", "failed"]);
 const batchItemIdArraySchema = z.array(z.string()).max(500);
 
 const batchItemIdsSchema = z
@@ -116,41 +115,18 @@ const batchOperationSummarySchema = z.object({
     total: z.number().int(),
     succeeded: z.number().int(),
     failed: z.number().int(),
-    skipped: z.number().int(),
-});
-
-const batchRestoreResultSchema = z.object({
-    itemType: recycleItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    parentFolderId: z.string().nullable().optional(),
-    restoredCount: z.number().int().optional(),
-});
-
-const batchPermanentlyDeleteResultSchema = z.object({
-    itemType: recycleItemTypeSchema,
-    itemId: z.string(),
-    outcome: batchItemOutcomeSchema,
-    message: z.string(),
-    code: z.string().optional(),
-    purgedFiles: z.number().int().optional(),
-    purgedFolders: z.number().int().optional(),
 });
 
 const batchRestoreResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchRestoreResultSchema),
 });
 
 const batchPermanentlyDeleteResponseSchema = z.object({
     status: batchOperationStatusSchema,
     message: z.string(),
     summary: batchOperationSummarySchema,
-    results: z.array(batchPermanentlyDeleteResultSchema),
 });
 
 const emptyQuerySchema = z.object({

--- a/apps/server/src/systems/recycle-bin/recycle-bin.schemas.ts
+++ b/apps/server/src/systems/recycle-bin/recycle-bin.schemas.ts
@@ -73,6 +73,86 @@ const permanentlyDeleteResponseSchema = z.object({
     purgedFolders: z.number().int(),
 });
 
+const batchItemOutcomeSchema = z.enum(["SUCCESS", "FAILED", "SKIPPED"]);
+const batchOperationStatusSchema = z.enum(["success", "partial_success", "failed"]);
+const batchItemIdArraySchema = z.array(z.string()).max(500);
+
+const batchItemIdsSchema = z
+    .object({
+        fileIds: batchItemIdArraySchema.optional(),
+        folderIds: batchItemIdArraySchema.optional(),
+    })
+    .strict()
+    .superRefine((value, context) => {
+        const totalIds = (value.fileIds?.length ?? 0) + (value.folderIds?.length ?? 0);
+        if (totalIds === 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "At least one fileId or folderId is required",
+                path: ["fileIds"],
+            });
+        }
+    });
+
+const batchRestoreBodySchema = z
+    .object({
+        destinationFolderId: z.string().optional(),
+        fileIds: batchItemIdArraySchema.optional(),
+        folderIds: batchItemIdArraySchema.optional(),
+    })
+    .strict()
+    .superRefine((value, context) => {
+        const totalIds = (value.fileIds?.length ?? 0) + (value.folderIds?.length ?? 0);
+        if (totalIds === 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "At least one fileId or folderId is required",
+                path: ["fileIds"],
+            });
+        }
+    });
+
+const batchOperationSummarySchema = z.object({
+    total: z.number().int(),
+    succeeded: z.number().int(),
+    failed: z.number().int(),
+    skipped: z.number().int(),
+});
+
+const batchRestoreResultSchema = z.object({
+    itemType: recycleItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    parentFolderId: z.string().nullable().optional(),
+    restoredCount: z.number().int().optional(),
+});
+
+const batchPermanentlyDeleteResultSchema = z.object({
+    itemType: recycleItemTypeSchema,
+    itemId: z.string(),
+    outcome: batchItemOutcomeSchema,
+    message: z.string(),
+    code: z.string().optional(),
+    purgedFiles: z.number().int().optional(),
+    purgedFolders: z.number().int().optional(),
+});
+
+const batchRestoreResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchRestoreResultSchema),
+});
+
+const batchPermanentlyDeleteResponseSchema = z.object({
+    status: batchOperationStatusSchema,
+    message: z.string(),
+    summary: batchOperationSummarySchema,
+    results: z.array(batchPermanentlyDeleteResultSchema),
+});
+
 const emptyQuerySchema = z.object({
     itemType: recycleItemTypeSchema.optional(),
 });
@@ -103,6 +183,8 @@ export type ListQuery = z.infer<typeof listQuerySchema>;
 export type DestinationFoldersQuery = z.infer<typeof destinationFoldersQuerySchema>;
 export type ItemParams = z.infer<typeof itemParamsSchema>;
 export type RestoreBody = z.infer<typeof restoreBodySchema>;
+export type BatchRestoreBody = z.infer<typeof batchRestoreBodySchema>;
+export type BatchPermanentlyDeleteBody = z.infer<typeof batchItemIdsSchema>;
 export type EmptyQuery = z.infer<typeof emptyQuerySchema>;
 export type PurgeBody = z.infer<typeof purgeBodySchema>;
 
@@ -116,6 +198,10 @@ export const { schemas: recycleBinSchemas, $ref } = buildJsonSchemas(
         restoreBodySchema,
         restoreResponseSchema,
         permanentlyDeleteResponseSchema,
+        batchRestoreBodySchema,
+        batchRestoreResponseSchema,
+        batchItemIdsSchema,
+        batchPermanentlyDeleteResponseSchema,
         emptyQuerySchema,
         emptyResponseSchema,
         purgeBodySchema,


### PR DESCRIPTION
## Issue
Folder and Recycle Bin workflows supported single-item actions, but selection mode allows users to operate on many files/folders at once. In practice, this created gaps for move/delete/restore flows, especially when mixed file+folder selections included nested folder trees or large selections.

## User Impact
Users can now batch move and batch delete from the folder page and batch restore/permanently-delete from Recycle Bin with deterministic summaries. Partial failures are surfaced clearly, and successful items still complete in the same operation.

## Root Cause
The backend and frontend were oriented around one-item mutations and lacked coordinated bulk APIs that understood folder hierarchies. Without hierarchy-aware filtering and batched request handling, nested selections could be double-counted, destination checks were incomplete for bulk actions, and large selections needed explicit chunking.

## Fix
Introduced dedicated batch APIs and schema contracts for folder and recycle-bin systems (`fileIds`/`folderIds`, max 500 per request, operation summaries):

- Added `POST /v1/folders/batch/move` and `POST /v1/folders/batch/delete`.
- Added `POST /v1/recycle-bin/items/batch/restore` and `POST /v1/recycle-bin/items/batch/permanently-delete`.
- Implemented ownership/deletion-state validation, destination permission checks, and hierarchy-aware filtering so nested folder selections are handled once.
- Updated folder move/delete logic to process subtree effects safely and report aggregate success/failed counts.
- Added Nova client API methods and Zod parsing for new payload/response contracts.
- Updated folder-page selection flows to chunk requests at 500 IDs, merge per-chunk summaries, invalidate affected queries, and show success/partial-failure toasts.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
