### PR TITLE
[codex] refactor(auth,folder,server): hard cutover and prune compatibility paths

### DIFF
--- a/apps/nova/src/features/auth/api.ts
+++ b/apps/nova/src/features/auth/api.ts
@@ -17,13 +17,9 @@ const userSchema = z.object({
     rootFolderId: z.string(),
 });
 
-const sessionExpiresAtSchema = z.union([z.date(), z.string().datetime()]).transform((value) => {
-    return value instanceof Date ? value.toISOString() : value;
-});
-
 const authSessionSchema = z.object({
     session: z.object({
-        expiresAt: sessionExpiresAtSchema,
+        expiresAt: z.string().datetime(),
     }),
     user: userSchema,
 });

--- a/apps/nova/src/features/auth/auth-client.ts
+++ b/apps/nova/src/features/auth/auth-client.ts
@@ -6,7 +6,16 @@ import { env } from "@/env";
 export const authClient = createAuthClient({
     baseURL: env.NEXT_PUBLIC_OPENCLOUD_SERVER_URL,
     basePath: "/api/auth",
-    fetchOptions: { credentials: "include" },
+    fetchOptions: {
+        credentials: "include",
+        jsonParser: (text) => {
+            if (!text) {
+                return null;
+            }
+
+            return JSON.parse(text) as unknown;
+        },
+    },
     plugins: [
         usernameClient(),
         inferAdditionalFields({

--- a/apps/nova/src/features/folder/api.ts
+++ b/apps/nova/src/features/folder/api.ts
@@ -33,38 +33,28 @@ const folderDetailsSchema = z
     }));
 
 const folderContentsPayloadSchema = z.object({
-    id: z.union([z.string(), z.number()]).transform((value) => String(value)),
+    id: z.string(),
     folders: z
         .array(
             z.object({
-                id: z.union([z.string(), z.number()]).transform((value) => String(value)),
+                id: z.string(),
                 name: z.string(),
-                createdAt: z
-                    .union([z.string().datetime(), z.date()])
-                    .transform((value) => (value instanceof Date ? value.toISOString() : value)),
+                createdAt: z.string().datetime(),
             }),
         )
         .default([]),
     files: z
         .array(
             z.object({
-                id: z.union([z.string(), z.number()]).transform((value) => String(value)),
+                id: z.string(),
                 name: z.string(),
-                sizeBytes: z.union([z.number().int(), z.string().regex(/^\d+$/), z.null()]).transform((value) => {
-                    if (value === null) {
-                        return null;
-                    }
-
-                    return typeof value === "string" ? Number(value) : value;
-                }),
-                createdAt: z
-                    .union([z.string().datetime(), z.date()])
-                    .transform((value) => (value instanceof Date ? value.toISOString() : value)),
+                sizeBytes: z.number().int().nullable(),
+                createdAt: z.string().datetime(),
             }),
         )
         .default([]),
-    limit: z.coerce.number().int().optional(),
-    offset: z.coerce.number().int().optional(),
+    limit: z.number().int().optional(),
+    offset: z.number().int().optional(),
 });
 
 const folderContentsSchema = folderContentsPayloadSchema.transform((value) => ({

--- a/apps/server/src/utils/authentication.ts
+++ b/apps/server/src/utils/authentication.ts
@@ -49,32 +49,14 @@ const buildHeaders = (request: FastifyRequest) => {
     return headers;
 };
 
-type SetCookieHeaderSource = Headers | Record<string, string | string[] | undefined>;
+type SetCookieHeaderSource = Headers;
 type SessionResolvedRequest = FastifyRequest & {
     _authSessionResolved?: boolean;
     _authConfigurationError?: boolean;
 };
 
 const extractSetCookies = (headers: SetCookieHeaderSource) => {
-    const headerApi = headers as { getSetCookie?: () => string[]; get?: (name: string) => string | null };
-    if (typeof headerApi.getSetCookie === "function") {
-        const setCookies = headerApi.getSetCookie();
-        if (setCookies.length > 0) {
-            return setCookies;
-        }
-    }
-    if (typeof headerApi.get === "function") {
-        const setCookie = headerApi.get("set-cookie");
-        if (setCookie) {
-            return [setCookie];
-        }
-    }
-
-    const raw = (headers as Record<string, string | string[] | undefined>)["set-cookie"];
-    if (!raw) {
-        return [];
-    }
-    return Array.isArray(raw) ? raw : [raw];
+    return headers.getSetCookie();
 };
 
 const appendSetCookies = (reply: FastifyReply, setCookies: string[]) => {

--- a/apps/server/src/utils/better-auth.ts
+++ b/apps/server/src/utils/better-auth.ts
@@ -58,16 +58,7 @@ const buildAuthRequest = (request: FastifyRequest) => {
 };
 
 const extractResponseSetCookies = (headers: Headers) => {
-    const headerApi = headers as { getSetCookie?: () => string[]; get?: (name: string) => string | null };
-    if (typeof headerApi.getSetCookie === "function") {
-        const setCookies = headerApi.getSetCookie();
-        if (setCookies.length > 0) {
-            return setCookies;
-        }
-    }
-
-    const fallback = headerApi.get ? headerApi.get("set-cookie") : headers.get("set-cookie");
-    return fallback ? [fallback] : [];
+    return headers.getSetCookie();
 };
 
 const appendSetCookies = (reply: FastifyReply, setCookies: string[]) => {


### PR DESCRIPTION
## Summary
This branch performs a **hard cutover** away from backwards-compatibility parsing and normalizes both Nova and server auth/folder handling around strict, current contracts. The goal is to remove legacy coercion paths rather than preserve transitional behavior.

## Hard Cutover Scope
- No legacy acceptance for mixed scalar/date types in Nova session and folder payload parsing.
- No fallback header extraction paths for `set-cookie` in server auth plumbing.
- Runtime assumptions now match current Better Auth + Fastify/Undici behavior only.

## Detailed Changes
### 1. Nova auth session parsing hardened
- File: `apps/nova/src/features/auth/api.ts`
- Removed compatibility union/transform for `session.expiresAt` (`Date | string -> string`).
- `authSessionSchema` now strictly requires `expiresAt: z.string().datetime()`.

### 2. Nova auth client kept strict-JSON
- File: `apps/nova/src/features/auth/auth-client.ts`
- Added explicit `fetchOptions.jsonParser` using plain `JSON.parse`.
- This prevents Better Auth’s default parser from reviving ISO strings into `Date` instances, so strict string schema validation stays consistent with the hard cutover.

### 3. Nova folder payload coercions removed
- File: `apps/nova/src/features/folder/api.ts`
- Removed ID coercion from `string | number` to `string` for folder/file IDs.
- Removed date coercion from `Date | string` to ISO string for `createdAt`.
- Removed `sizeBytes` coercion from numeric-string to number.
- Removed `limit/offset` coercion (`z.coerce.number`) and now require numeric values directly.

### 4. Server auth cookie extraction fallback paths pruned
- File: `apps/server/src/utils/authentication.ts`
- Narrowed header source to `Headers` only.
- Removed fallback branches for `.get("set-cookie")` and raw record indexing.
- Cookie extraction now relies solely on `headers.getSetCookie()`.

### 5. Server Better Auth response cookie extraction simplified
- File: `apps/server/src/utils/better-auth.ts`
- Removed fallback logic for `.get("set-cookie")`.
- Cookie extraction now relies solely on `headers.getSetCookie()`.

## Why This Is Safe for the Cutover
- Server-side folder response schemas and handlers already emit strict string IDs and ISO datetime strings.
- Better Auth endpoint typings return `Headers` for `returnHeaders` paths used by server utilities.
- The explicit Nova auth JSON parser ensures strict datetime string parsing is enforced consistently without reintroducing backward-compatibility schema unions.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run prettier:write`
- Verified runtime behavior before/after:
  - Before fix: default Better Auth parsing could produce `Date` for `expiresAt`, causing strict string schema failure.
  - After fix: session payload remains JSON-string based and passes strict schema validation.
